### PR TITLE
新增快捷面板位置配置和提交前检查机制

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+
+echo "[pre-commit] running staged checks"
+bash "$ROOT_DIR/scripts/check.sh" --staged

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: dev build run test package
+.PHONY: dev build run test check check-staged install-hooks package
 
 dev:
 	bash ./scripts/dev.sh
@@ -13,6 +13,15 @@ run:
 
 test:
 	swift test
+
+check:
+	bash ./scripts/check.sh --all
+
+check-staged:
+	bash ./scripts/check.sh --staged
+
+install-hooks:
+	bash ./scripts/install-hooks.sh
 
 package:
 	VERSION="$(VERSION)" \

--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,10 @@ test:
 	swift test
 
 package:
+	VERSION="$(VERSION)" \
+	ARCH="$(ARCH)" \
+	CONFIGURATION="$(CONFIGURATION)" \
+	BUNDLE_ID="$(BUNDLE_ID)" \
+	DIST_DIR="$(DIST_DIR)" \
+	CODESIGN_IDENTITY="$(CODESIGN_IDENTITY)" \
 	bash ./scripts/package.sh

--- a/README.md
+++ b/README.md
@@ -162,6 +162,26 @@ make dev
 This starts the app and automatically restarts `swift run` when files under `Sources/`, `Tests/`, or `Package.swift` change.
 If `fswatch` is installed, the script uses it. Otherwise it falls back to polling once per second.
 
+### Checks
+
+```bash
+make check
+```
+
+This runs repository-wide fast checks:
+
+- `swift build` when Swift sources are present
+- `plutil -lint` for `.strings` files
+- `bash -n` for shell scripts
+
+To enable commit-time staged checks:
+
+```bash
+make install-hooks
+```
+
+After that, each commit runs `.githooks/pre-commit`, which only checks the staged file set.
+
 ### Packaging
 
 ```bash

--- a/README_zh.md
+++ b/README_zh.md
@@ -162,6 +162,26 @@ make dev
 这个命令会启动应用，并在 `Sources/`、`Tests/` 或 `Package.swift` 发生变化后自动重新执行 `swift run`。
 如果系统里装了 `fswatch`，脚本会优先使用它；否则退化为每秒轮询一次。
 
+### 检查
+
+```bash
+make check
+```
+
+这个命令会执行全仓库的快速检查：
+
+- Swift 源码存在时执行 `swift build`
+- 对 `.strings` 文件执行 `plutil -lint`
+- 对 shell 脚本执行 `bash -n`
+
+如果要启用提交前自动检查：
+
+```bash
+make install-hooks
+```
+
+执行后会把 Git hooks 指向 `.githooks`，之后每次提交都会自动检查暂存区文件。
+
 ### 打包
 
 ```bash

--- a/Sources/App/PasteMemoApp.swift
+++ b/Sources/App/PasteMemoApp.swift
@@ -103,10 +103,8 @@ struct PasteMemoApp: App {
         } label: {
             if let image = Self.menuBarIcon(paused: clipboardManager.isPaused, relay: RelayManager.shared.isActive, filled: menuBarIconStyle == "filled") {
                 Image(nsImage: image)
-                    .background(MenuBarAnchorReporter())
             } else {
                 Image(systemName: "doc.on.clipboard")
-                    .background(MenuBarAnchorReporter())
             }
         }
         .menuBarExtraStyle(.menu)

--- a/Sources/App/PasteMemoApp.swift
+++ b/Sources/App/PasteMemoApp.swift
@@ -103,8 +103,10 @@ struct PasteMemoApp: App {
         } label: {
             if let image = Self.menuBarIcon(paused: clipboardManager.isPaused, relay: RelayManager.shared.isActive, filled: menuBarIconStyle == "filled") {
                 Image(nsImage: image)
+                    .background(MenuBarAnchorReporter())
             } else {
                 Image(systemName: "doc.on.clipboard")
+                    .background(MenuBarAnchorReporter())
             }
         }
         .menuBarExtraStyle(.menu)

--- a/Sources/Engine/QuickPanelPositioning.swift
+++ b/Sources/Engine/QuickPanelPositioning.swift
@@ -1,0 +1,197 @@
+import AppKit
+import SwiftUI
+import ApplicationServices
+
+enum QuickPanelPositionMode: String, CaseIterable {
+    case remembered
+    case cursor
+    case menuBarIcon
+    case windowCenter
+    case screenCenter
+
+    var titleKey: String {
+        switch self {
+        case .remembered: "settings.quickPanelPosition.remembered"
+        case .cursor: "settings.quickPanelPosition.cursor"
+        case .menuBarIcon: "settings.quickPanelPosition.menuBarIcon"
+        case .windowCenter: "settings.quickPanelPosition.windowCenter"
+        case .screenCenter: "settings.quickPanelPosition.screenCenter"
+        }
+    }
+}
+
+enum QuickPanelScreenTarget: String, CaseIterable {
+    case active
+    case specified
+
+    var titleKey: String {
+        switch self {
+        case .active: "settings.quickPanelTargetScreen.active"
+        case .specified: "settings.quickPanelTargetScreen.specified"
+        }
+    }
+}
+
+enum QuickPanelPositionSettings {
+    static let modeKey = "quickPanelPositionMode"
+    static let screenTargetKey = "quickPanelScreenTarget"
+    static let specifiedScreenIDKey = "quickPanelSpecifiedScreenID"
+}
+
+struct ScreenOption: Identifiable, Hashable {
+    let id: String
+    let name: String
+}
+
+enum ScreenLocator {
+    static func identifier(for screen: NSScreen) -> String? {
+        guard let number = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber else {
+            return nil
+        }
+        return number.stringValue
+    }
+
+    static func options() -> [ScreenOption] {
+        let screens = NSScreen.screens
+        let grouped = Dictionary(grouping: screens, by: \.localizedName)
+
+        return screens.compactMap { screen in
+            guard let id = identifier(for: screen) else { return nil }
+            let isDuplicated = (grouped[screen.localizedName]?.count ?? 0) > 1
+            let name = isDuplicated ? "\(screen.localizedName) (\(id))" : screen.localizedName
+            return ScreenOption(id: id, name: name)
+        }
+    }
+
+    static func screen(for identifier: String?) -> NSScreen? {
+        guard let identifier else { return nil }
+        return NSScreen.screens.first { self.identifier(for: $0) == identifier }
+    }
+
+    static func screen(containing point: CGPoint) -> NSScreen? {
+        NSScreen.screens.first { $0.frame.contains(point) }
+    }
+
+    static func screen(for frame: CGRect) -> NSScreen? {
+        let center = CGPoint(x: frame.midX, y: frame.midY)
+        if let screen = screen(containing: center) {
+            return screen
+        }
+
+        return NSScreen.screens.max { lhs, rhs in
+            lhs.frame.intersection(frame).area < rhs.frame.intersection(frame).area
+        }
+    }
+}
+
+enum ActiveWindowLocator {
+    @MainActor
+    static func focusedWindowFrame() -> CGRect? {
+        guard let app = NSWorkspace.shared.frontmostApplication else { return nil }
+
+        let appElement = AXUIElementCreateApplication(app.processIdentifier)
+        var windowRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(appElement, kAXFocusedWindowAttribute as CFString, &windowRef) == .success,
+              let windowRef
+        else {
+            return nil
+        }
+        let window = windowRef as! AXUIElement
+
+        var positionRef: CFTypeRef?
+        var sizeRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(window, kAXPositionAttribute as CFString, &positionRef) == .success,
+              AXUIElementCopyAttributeValue(window, kAXSizeAttribute as CFString, &sizeRef) == .success,
+              let positionRef,
+              let sizeRef
+        else {
+            return nil
+        }
+        let positionValue = positionRef as! AXValue
+        let sizeValue = sizeRef as! AXValue
+
+        var position = CGPoint.zero
+        var size = CGSize.zero
+        guard AXValueGetValue(positionValue, .cgPoint, &position),
+              AXValueGetValue(sizeValue, .cgSize, &size)
+        else {
+            return nil
+        }
+
+        return CGRect(origin: position, size: size)
+    }
+
+    @MainActor
+    static func activeScreen() -> NSScreen? {
+        if let frame = focusedWindowFrame(), let screen = ScreenLocator.screen(for: frame) {
+            return screen
+        }
+        return NSScreen.main ?? NSScreen.screenWithMouse ?? NSScreen.screens.first
+    }
+}
+
+@MainActor
+final class MenuBarAnchorStore: ObservableObject {
+    static let shared = MenuBarAnchorStore()
+
+    @Published private(set) var frameInScreen: CGRect?
+    private(set) var screenID: String?
+
+    private init() {}
+
+    func update(frame: CGRect?, screenID: String?) {
+        frameInScreen = frame
+        self.screenID = screenID
+    }
+}
+
+struct MenuBarAnchorReporter: NSViewRepresentable {
+    func makeNSView(context: Context) -> MenuBarAnchorTrackingView {
+        MenuBarAnchorTrackingView()
+    }
+
+    func updateNSView(_ nsView: MenuBarAnchorTrackingView, context: Context) {
+        nsView.scheduleUpdate()
+    }
+}
+
+final class MenuBarAnchorTrackingView: NSView {
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        scheduleUpdate()
+    }
+
+    override func layout() {
+        super.layout()
+        scheduleUpdate()
+    }
+
+    func scheduleUpdate() {
+        DispatchQueue.main.async { [weak self] in
+            self?.reportAnchor()
+        }
+    }
+
+    private func reportAnchor() {
+        guard let window else { return }
+
+        let frameInWindow = convert(bounds, to: nil)
+        let frameInScreen = window.convertToScreen(frameInWindow)
+        let screen = window.screen ?? ScreenLocator.screen(containing: frameInScreen.center)
+
+        MenuBarAnchorStore.shared.update(
+            frame: frameInScreen,
+            screenID: screen.flatMap(ScreenLocator.identifier(for:))
+        )
+    }
+}
+
+private extension CGRect {
+    var area: CGFloat {
+        width * height
+    }
+
+    var center: CGPoint {
+        CGPoint(x: midX, y: midY)
+    }
+}

--- a/Sources/Engine/QuickPanelPositioning.swift
+++ b/Sources/Engine/QuickPanelPositioning.swift
@@ -87,7 +87,9 @@ enum ScreenLocator {
 enum ActiveWindowLocator {
     @MainActor
     static func focusedWindowFrame() -> CGRect? {
-        guard let app = NSWorkspace.shared.frontmostApplication else { return nil }
+        guard let app = NSWorkspace.shared.frontmostApplication else {
+            return nil
+        }
 
         let appElement = AXUIElementCreateApplication(app.processIdentifier)
         var windowRef: CFTypeRef?
@@ -97,6 +99,16 @@ enum ActiveWindowLocator {
             return nil
         }
         let window = windowRef as! AXUIElement
+
+        // Reject non-standard windows (e.g. Finder desktop pseudo-window, which spans all displays).
+        var subroleRef: CFTypeRef?
+        AXUIElementCopyAttributeValue(window, kAXSubroleAttribute as CFString, &subroleRef)
+        let subrole = subroleRef as? String
+        if subrole != kAXStandardWindowSubrole as String,
+           subrole != kAXDialogSubrole as String,
+           subrole != kAXFloatingWindowSubrole as String {
+            return nil
+        }
 
         var positionRef: CFTypeRef?
         var sizeRef: CFTypeRef?
@@ -118,7 +130,18 @@ enum ActiveWindowLocator {
             return nil
         }
 
-        return CGRect(origin: position, size: size)
+        return Self.axRectToCocoa(CGRect(origin: position, size: size))
+    }
+
+    /// Convert a rect from AX global coords (origin = top-left of primary screen, Y down)
+    /// to Cocoa screen coords (origin = bottom-left of primary screen, Y up).
+    @MainActor
+    static func axRectToCocoa(_ rect: CGRect) -> CGRect? {
+        guard let primary = NSScreen.screens.first(where: { $0.frame.origin == .zero })
+                ?? NSScreen.main
+        else { return nil }
+        let flippedY = primary.frame.height - rect.origin.y - rect.size.height
+        return CGRect(x: rect.origin.x, y: flippedY, width: rect.size.width, height: rect.size.height)
     }
 
     @MainActor
@@ -126,63 +149,24 @@ enum ActiveWindowLocator {
         if let frame = focusedWindowFrame(), let screen = ScreenLocator.screen(for: frame) {
             return screen
         }
-        return NSScreen.main ?? NSScreen.screenWithMouse ?? NSScreen.screens.first
+        return NSScreen.screenWithMouse ?? NSScreen.main ?? NSScreen.screens.first
     }
 }
 
-@MainActor
-final class MenuBarAnchorStore: ObservableObject {
-    static let shared = MenuBarAnchorStore()
-
-    @Published private(set) var frameInScreen: CGRect?
-    private(set) var screenID: String?
-
-    private init() {}
-
-    func update(frame: CGRect?, screenID: String?) {
-        frameInScreen = frame
-        self.screenID = screenID
-    }
-}
-
-struct MenuBarAnchorReporter: NSViewRepresentable {
-    func makeNSView(context: Context) -> MenuBarAnchorTrackingView {
-        MenuBarAnchorTrackingView()
-    }
-
-    func updateNSView(_ nsView: MenuBarAnchorTrackingView, context: Context) {
-        nsView.scheduleUpdate()
-    }
-}
-
-final class MenuBarAnchorTrackingView: NSView {
-    override func viewDidMoveToWindow() {
-        super.viewDidMoveToWindow()
-        scheduleUpdate()
-    }
-
-    override func layout() {
-        super.layout()
-        scheduleUpdate()
-    }
-
-    func scheduleUpdate() {
-        DispatchQueue.main.async { [weak self] in
-            self?.reportAnchor()
+enum MenuBarIconLocator {
+    @MainActor
+    static func iconFrame() -> (frame: CGRect, screen: NSScreen)? {
+        for window in NSApp.windows {
+            let className = String(describing: type(of: window))
+            guard className.contains("StatusBar") else { continue }
+            let frame = window.frame
+            guard frame.width > 0, frame.height > 0 else { continue }
+            let screen = window.screen
+                ?? ScreenLocator.screen(containing: CGPoint(x: frame.midX, y: frame.midY))
+            guard let screen else { continue }
+            return (frame, screen)
         }
-    }
-
-    private func reportAnchor() {
-        guard let window else { return }
-
-        let frameInWindow = convert(bounds, to: nil)
-        let frameInScreen = window.convertToScreen(frameInWindow)
-        let screen = window.screen ?? ScreenLocator.screen(containing: frameInScreen.center)
-
-        MenuBarAnchorStore.shared.update(
-            frame: frameInScreen,
-            screenID: screen.flatMap(ScreenLocator.identifier(for:))
-        )
+        return nil
     }
 }
 

--- a/Sources/Localization/de.lproj/Localizable.strings
+++ b/Sources/Localization/de.lproj/Localizable.strings
@@ -111,7 +111,7 @@
 "action.newGroup" = "Neue Gruppe…";
 "action.editGroup" = "Gruppe bearbeiten…";
 "action.deleteGroup" = "Gruppe löschen";
-"action.deleteGroupConfirm" = "Möchten Sie die Gruppe „%@" wirklich löschen? Die Elemente in der Gruppe werden nicht gelöscht.";
+"action.deleteGroupConfirm" = "Möchten Sie die Gruppe „%@“ wirklich löschen? Die Elemente in der Gruppe werden nicht gelöscht.";
 "action.removeFromGroup" = "Aus Gruppe entfernen";
 "action.changeIcon" = "Symbol ändern…";
 "action.clearConfirm" = "Alle Elemente außer Favoriten und angehefteten Elementen werden gelöscht.";

--- a/Sources/Localization/de.lproj/Localizable.strings
+++ b/Sources/Localization/de.lproj/Localizable.strings
@@ -135,6 +135,16 @@
 "settings.retentionDays.cleanConfirm" = "%d Einträge außerhalb des Aufbewahrungszeitraums werden gelöscht";
 "settings.retentionDays.cleanWarning" = "Dieser Vorgang kann nicht rückgängig gemacht werden. Fortfahren?";
 "settings.display" = "Anzeige";
+"settings.quickPanelPosition" = "Position des Schnellpanels";
+"settings.quickPanelPosition.remembered" = "Letzte Position merken";
+"settings.quickPanelPosition.cursor" = "Cursor";
+"settings.quickPanelPosition.menuBarIcon" = "Menüleistensymbol";
+"settings.quickPanelPosition.windowCenter" = "Mitte des aktiven Fensters";
+"settings.quickPanelPosition.screenCenter" = "Bildschirmmitte";
+"settings.quickPanelTargetScreen" = "Zielbildschirm";
+"settings.quickPanelTargetScreen.active" = "Aktiver Bildschirm";
+"settings.quickPanelTargetScreen.specified" = "Ausgewählter Bildschirm";
+"settings.quickPanelSpecifiedScreen" = "Ausgewähltes Display";
 "settings.behavior" = "Verhalten";
 "settings.preferences" = "Einstellungen";
 "settings.showLinkURL" = "URL statt Seitentitel für Links anzeigen";

--- a/Sources/Localization/en.lproj/Localizable.strings
+++ b/Sources/Localization/en.lproj/Localizable.strings
@@ -120,6 +120,16 @@
 "settings.retentionDays.cleanConfirm" = "%d items beyond the retention period will be deleted";
 "settings.retentionDays.cleanWarning" = "This action cannot be undone. Are you sure?";
 "settings.display" = "Display";
+"settings.quickPanelPosition" = "Quick Panel Position";
+"settings.quickPanelPosition.remembered" = "Remember Last Position";
+"settings.quickPanelPosition.cursor" = "Cursor";
+"settings.quickPanelPosition.menuBarIcon" = "Menu Bar Icon";
+"settings.quickPanelPosition.windowCenter" = "Active Window Center";
+"settings.quickPanelPosition.screenCenter" = "Screen Center";
+"settings.quickPanelTargetScreen" = "Target Screen";
+"settings.quickPanelTargetScreen.active" = "Active Screen";
+"settings.quickPanelTargetScreen.specified" = "Specified Screen";
+"settings.quickPanelSpecifiedScreen" = "Specified Display";
 "settings.behavior" = "Behavior";
 "settings.preferences" = "Preferences";
 "settings.showLinkURL" = "Show URL instead of page title for links";

--- a/Sources/Localization/es.lproj/Localizable.strings
+++ b/Sources/Localization/es.lproj/Localizable.strings
@@ -135,6 +135,16 @@
 "settings.retentionDays.cleanConfirm" = "Se eliminarán %d elementos que superan el período de retención";
 "settings.retentionDays.cleanWarning" = "Esta acción no se puede deshacer. ¿Continuar?";
 "settings.display" = "Visualización";
+"settings.quickPanelPosition" = "Posición del panel rápido";
+"settings.quickPanelPosition.remembered" = "Recordar la última posición";
+"settings.quickPanelPosition.cursor" = "Cursor";
+"settings.quickPanelPosition.menuBarIcon" = "Icono de la barra de menús";
+"settings.quickPanelPosition.windowCenter" = "Centro de la ventana activa";
+"settings.quickPanelPosition.screenCenter" = "Centro de la pantalla";
+"settings.quickPanelTargetScreen" = "Pantalla de destino";
+"settings.quickPanelTargetScreen.active" = "Pantalla activa";
+"settings.quickPanelTargetScreen.specified" = "Pantalla específica";
+"settings.quickPanelSpecifiedScreen" = "Monitor específico";
 "settings.behavior" = "Comportamiento";
 "settings.preferences" = "Preferencias";
 "settings.showLinkURL" = "Mostrar URL en lugar del título para enlaces";

--- a/Sources/Localization/fr.lproj/Localizable.strings
+++ b/Sources/Localization/fr.lproj/Localizable.strings
@@ -135,6 +135,16 @@
 "settings.retentionDays.cleanConfirm" = "%d éléments au-delà de la période de rétention seront supprimés";
 "settings.retentionDays.cleanWarning" = "Cette action est irréversible. Continuer ?";
 "settings.display" = "Affichage";
+"settings.quickPanelPosition" = "Position du panneau rapide";
+"settings.quickPanelPosition.remembered" = "Mémoriser la dernière position";
+"settings.quickPanelPosition.cursor" = "Curseur";
+"settings.quickPanelPosition.menuBarIcon" = "Icône de la barre des menus";
+"settings.quickPanelPosition.windowCenter" = "Centre de la fenêtre active";
+"settings.quickPanelPosition.screenCenter" = "Centre de l'écran";
+"settings.quickPanelTargetScreen" = "Écran cible";
+"settings.quickPanelTargetScreen.active" = "Écran actif";
+"settings.quickPanelTargetScreen.specified" = "Écran choisi";
+"settings.quickPanelSpecifiedScreen" = "Moniteur choisi";
 "settings.behavior" = "Comportement";
 "settings.preferences" = "Préférences";
 "settings.showLinkURL" = "Afficher l'URL au lieu du titre pour les liens";

--- a/Sources/Localization/id.lproj/Localizable.strings
+++ b/Sources/Localization/id.lproj/Localizable.strings
@@ -110,6 +110,16 @@
 "settings.retentionDays.cleanConfirm" = "%d item di luar periode penyimpanan akan dihapus";
 "settings.retentionDays.cleanWarning" = "Tindakan ini tidak dapat dibatalkan. Lanjutkan?";
 "settings.display" = "Tampilan";
+"settings.quickPanelPosition" = "Posisi panel cepat";
+"settings.quickPanelPosition.remembered" = "Ingat posisi terakhir";
+"settings.quickPanelPosition.cursor" = "Kursor";
+"settings.quickPanelPosition.menuBarIcon" = "Ikon bar menu";
+"settings.quickPanelPosition.windowCenter" = "Tengah jendela aktif";
+"settings.quickPanelPosition.screenCenter" = "Tengah layar";
+"settings.quickPanelTargetScreen" = "Layar target";
+"settings.quickPanelTargetScreen.active" = "Layar aktif";
+"settings.quickPanelTargetScreen.specified" = "Layar tertentu";
+"settings.quickPanelSpecifiedScreen" = "Display tertentu";
 "settings.behavior" = "Perilaku";
 "settings.preferences" = "Preferensi";
 "settings.showLinkURL" = "Tampilkan URL alih-alih judul halaman untuk tautan";

--- a/Sources/Localization/it.lproj/Localizable.strings
+++ b/Sources/Localization/it.lproj/Localizable.strings
@@ -110,6 +110,16 @@
 "settings.retentionDays.cleanConfirm" = "%d elementi oltre il periodo di conservazione verranno eliminati";
 "settings.retentionDays.cleanWarning" = "Questa azione non può essere annullata. Continuare?";
 "settings.display" = "Visualizzazione";
+"settings.quickPanelPosition" = "Posizione del pannello rapido";
+"settings.quickPanelPosition.remembered" = "Ricorda l'ultima posizione";
+"settings.quickPanelPosition.cursor" = "Cursore";
+"settings.quickPanelPosition.menuBarIcon" = "Icona barra menu";
+"settings.quickPanelPosition.windowCenter" = "Centro finestra attiva";
+"settings.quickPanelPosition.screenCenter" = "Centro schermo";
+"settings.quickPanelTargetScreen" = "Schermo di destinazione";
+"settings.quickPanelTargetScreen.active" = "Schermo attivo";
+"settings.quickPanelTargetScreen.specified" = "Schermo specificato";
+"settings.quickPanelSpecifiedScreen" = "Display specificato";
 "settings.behavior" = "Comportamento";
 "settings.preferences" = "Preferenze";
 "settings.showLinkURL" = "Mostra URL invece del titolo per i link";

--- a/Sources/Localization/ja.lproj/Localizable.strings
+++ b/Sources/Localization/ja.lproj/Localizable.strings
@@ -405,7 +405,7 @@
 "cmd.pasteAsFile" = "ファイルとしてペースト";
 "cmd.pastePath" = "パスをペースト";
 "cmd.retryOCR" = "OCRを再試行";
-"cmd.openInPreview" = ""プレビュー"で開く";
+"cmd.openInPreview" = "「プレビュー」で開く";
 "cmd.andNewLine" = "＋改行";
 "cmd.transform" = "変換";
 

--- a/Sources/Localization/ja.lproj/Localizable.strings
+++ b/Sources/Localization/ja.lproj/Localizable.strings
@@ -143,6 +143,16 @@
 "settings.retentionDays.cleanConfirm" = "保持期間を超えた%d件の項目が削除されます";
 "settings.retentionDays.cleanWarning" = "この操作は元に戻せません。続行しますか？";
 "settings.display" = "表示";
+"settings.quickPanelPosition" = "クイックパネルの位置";
+"settings.quickPanelPosition.remembered" = "前回の位置を記憶";
+"settings.quickPanelPosition.cursor" = "カーソル";
+"settings.quickPanelPosition.menuBarIcon" = "メニューバーアイコン";
+"settings.quickPanelPosition.windowCenter" = "アクティブウィンドウの中央";
+"settings.quickPanelPosition.screenCenter" = "画面中央";
+"settings.quickPanelTargetScreen" = "対象画面";
+"settings.quickPanelTargetScreen.active" = "アクティブ画面";
+"settings.quickPanelTargetScreen.specified" = "指定画面";
+"settings.quickPanelSpecifiedScreen" = "指定ディスプレイ";
 "settings.behavior" = "動作";
 "settings.preferences" = "環境設定";
 "settings.ocr" = "画像OCR";

--- a/Sources/Localization/ko.lproj/Localizable.strings
+++ b/Sources/Localization/ko.lproj/Localizable.strings
@@ -135,6 +135,16 @@
 "settings.retentionDays.cleanConfirm" = "보관 기간을 초과한 %d개 항목이 삭제됩니다";
 "settings.retentionDays.cleanWarning" = "이 작업은 되돌릴 수 없습니다. 계속하시겠습니까?";
 "settings.display" = "표시";
+"settings.quickPanelPosition" = "빠른 패널 위치";
+"settings.quickPanelPosition.remembered" = "마지막 위치 기억";
+"settings.quickPanelPosition.cursor" = "커서";
+"settings.quickPanelPosition.menuBarIcon" = "메뉴 막대 아이콘";
+"settings.quickPanelPosition.windowCenter" = "활성 창 중앙";
+"settings.quickPanelPosition.screenCenter" = "화면 중앙";
+"settings.quickPanelTargetScreen" = "대상 화면";
+"settings.quickPanelTargetScreen.active" = "활성 화면";
+"settings.quickPanelTargetScreen.specified" = "지정 화면";
+"settings.quickPanelSpecifiedScreen" = "지정 디스플레이";
 "settings.behavior" = "동작";
 "settings.preferences" = "환경설정";
 "settings.showLinkURL" = "링크를 페이지 제목 대신 URL로 표시";

--- a/Sources/Localization/ru.lproj/Localizable.strings
+++ b/Sources/Localization/ru.lproj/Localizable.strings
@@ -110,6 +110,16 @@
 "settings.retentionDays.cleanConfirm" = "Будет удалено %d записей за пределами срока хранения";
 "settings.retentionDays.cleanWarning" = "Это действие нельзя отменить. Продолжить?";
 "settings.display" = "Отображение";
+"settings.quickPanelPosition" = "Положение быстрой панели";
+"settings.quickPanelPosition.remembered" = "Запоминать прошлую позицию";
+"settings.quickPanelPosition.cursor" = "Курсор";
+"settings.quickPanelPosition.menuBarIcon" = "Значок в строке меню";
+"settings.quickPanelPosition.windowCenter" = "Центр активного окна";
+"settings.quickPanelPosition.screenCenter" = "Центр экрана";
+"settings.quickPanelTargetScreen" = "Целевой экран";
+"settings.quickPanelTargetScreen.active" = "Активный экран";
+"settings.quickPanelTargetScreen.specified" = "Указанный экран";
+"settings.quickPanelSpecifiedScreen" = "Указанный дисплей";
 "settings.behavior" = "Поведение";
 "settings.preferences" = "Настройки";
 "settings.showLinkURL" = "Показывать URL вместо заголовка для ссылок";

--- a/Sources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Localization/zh-Hans.lproj/Localizable.strings
@@ -120,6 +120,16 @@
 "settings.retentionDays.cleanConfirm" = "将删除 %d 条超出保留期的记录";
 "settings.retentionDays.cleanWarning" = "此操作不可恢复，确定要继续吗？";
 "settings.display" = "显示";
+"settings.quickPanelPosition" = "快捷面板位置";
+"settings.quickPanelPosition.remembered" = "记住上次位置";
+"settings.quickPanelPosition.cursor" = "光标";
+"settings.quickPanelPosition.menuBarIcon" = "菜单栏图标";
+"settings.quickPanelPosition.windowCenter" = "活动窗口中心";
+"settings.quickPanelPosition.screenCenter" = "屏幕中央";
+"settings.quickPanelTargetScreen" = "目标屏幕";
+"settings.quickPanelTargetScreen.active" = "活动屏幕";
+"settings.quickPanelTargetScreen.specified" = "指定屏幕";
+"settings.quickPanelSpecifiedScreen" = "指定显示器";
 "settings.behavior" = "行为";
 "settings.preferences" = "偏好";
 "settings.showLinkURL" = "链接显示原始网址而非页面标题";

--- a/Sources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Localization/zh-Hant.lproj/Localizable.strings
@@ -111,6 +111,16 @@
 "settings.retentionDays.cleanConfirm" = "將刪除 %d 條超出保留期的記錄";
 "settings.retentionDays.cleanWarning" = "此操作不可恢復，確定要繼續嗎？";
 "settings.display" = "顯示";
+"settings.quickPanelPosition" = "快捷面板位置";
+"settings.quickPanelPosition.remembered" = "記住上次位置";
+"settings.quickPanelPosition.cursor" = "游標";
+"settings.quickPanelPosition.menuBarIcon" = "選單列圖示";
+"settings.quickPanelPosition.windowCenter" = "目前視窗中心";
+"settings.quickPanelPosition.screenCenter" = "螢幕中央";
+"settings.quickPanelTargetScreen" = "目標螢幕";
+"settings.quickPanelTargetScreen.active" = "目前螢幕";
+"settings.quickPanelTargetScreen.specified" = "指定螢幕";
+"settings.quickPanelSpecifiedScreen" = "指定顯示器";
 "settings.behavior" = "行為";
 "settings.preferences" = "偏好";
 "settings.showLinkURL" = "連結顯示原始網址而非頁面標題";

--- a/Sources/Views/QuickPanel/QuickPanelWindowController.swift
+++ b/Sources/Views/QuickPanel/QuickPanelWindowController.swift
@@ -55,7 +55,7 @@ final class QuickPanelWindowController {
 
     private var positionMode: QuickPanelPositionMode {
         let rawValue = UserDefaults.standard.string(forKey: QuickPanelPositionSettings.modeKey)
-        return QuickPanelPositionMode(rawValue: rawValue ?? "") ?? .remembered
+        return QuickPanelPositionMode(rawValue: rawValue ?? "") ?? .cursor
     }
 
     private var screenTarget: QuickPanelScreenTarget {

--- a/Sources/Views/QuickPanel/QuickPanelWindowController.swift
+++ b/Sources/Views/QuickPanel/QuickPanelWindowController.swift
@@ -55,7 +55,7 @@ final class QuickPanelWindowController {
 
     private var positionMode: QuickPanelPositionMode {
         let rawValue = UserDefaults.standard.string(forKey: QuickPanelPositionSettings.modeKey)
-        return QuickPanelPositionMode(rawValue: rawValue ?? "") ?? .cursor
+        return QuickPanelPositionMode(rawValue: rawValue ?? "") ?? .screenCenter
     }
 
     private var screenTarget: QuickPanelScreenTarget {
@@ -302,18 +302,12 @@ final class QuickPanelWindowController {
     }
 
     private func positionAtMenuBarIcon(_ panel: NSPanel) {
-        if let frame = MenuBarAnchorStore.shared.frameInScreen {
-            let center = CGPoint(x: frame.midX, y: frame.midY)
-            let screen = ScreenLocator.screen(containing: center)
-                ?? MenuBarAnchorStore.shared.screenID.flatMap(ScreenLocator.screen(for:))
-                ?? resolveTargetScreen()
-            guard let screen else { return }
-
+        if let anchor = MenuBarIconLocator.iconFrame() {
             let origin = CGPoint(
-                x: frame.midX - panel.frame.width / 2,
-                y: frame.minY - panel.frame.height - 8
+                x: anchor.frame.midX - panel.frame.width / 2,
+                y: anchor.frame.minY - panel.frame.height - 8
             )
-            setClampedOrigin(origin, for: panel, on: screen)
+            setClampedOrigin(origin, for: panel, on: anchor.screen)
             return
         }
 

--- a/Sources/Views/QuickPanel/QuickPanelWindowController.swift
+++ b/Sources/Views/QuickPanel/QuickPanelWindowController.swift
@@ -10,9 +10,10 @@ private let DEFAULT_WIDTH: CGFloat = 750
 private let DEFAULT_HEIGHT: CGFloat = 510
 private let MIN_WIDTH: CGFloat = 500
 private let MIN_HEIGHT: CGFloat = 350
-private let VERTICAL_OFFSET: CGFloat = 100
+private let TOP_INSET_RATIO: CGFloat = 0.15
 private let SIZE_KEY = "quickPanelSize"
 private let POSITION_KEY = "quickPanelPosition"
+private let POSITION_SCREEN_KEY = "quickPanelPosition.screenID"
 
 private class KeyablePanel: NSPanel {
     override var canBecomeKey: Bool { true }
@@ -50,6 +51,21 @@ final class QuickPanelWindowController {
     private var panelHeight: CGFloat {
         let saved = UserDefaults.standard.double(forKey: "\(SIZE_KEY).height")
         return saved > 0 ? max(saved, MIN_HEIGHT) : DEFAULT_HEIGHT
+    }
+
+    private var positionMode: QuickPanelPositionMode {
+        let rawValue = UserDefaults.standard.string(forKey: QuickPanelPositionSettings.modeKey)
+        return QuickPanelPositionMode(rawValue: rawValue ?? "") ?? .remembered
+    }
+
+    private var screenTarget: QuickPanelScreenTarget {
+        let rawValue = UserDefaults.standard.string(forKey: QuickPanelPositionSettings.screenTargetKey)
+        return QuickPanelScreenTarget(rawValue: rawValue ?? "") ?? .active
+    }
+
+    private var specifiedScreenID: String? {
+        let value = UserDefaults.standard.string(forKey: QuickPanelPositionSettings.specifiedScreenIDKey)
+        return value?.isEmpty == true ? nil : value
     }
 
     private init() {}
@@ -222,14 +238,27 @@ final class QuickPanelWindowController {
         return panel
     }
 
-    /// Position panel on the screen where the mouse is, using saved relative offset if available.
     private func positionPanel(_ panel: NSPanel) {
-        let screen = NSScreen.screenWithMouse ?? NSScreen.main ?? NSScreen.screens.first
-        guard let screen else { return }
-        let visibleFrame = screen.visibleFrame
+        switch positionMode {
+        case .remembered:
+            positionRemembered(panel)
+        case .cursor:
+            positionAtCursor(panel)
+        case .menuBarIcon:
+            positionAtMenuBarIcon(panel)
+        case .windowCenter:
+            positionAtWindowCenter(panel)
+        case .screenCenter:
+            positionAtScreenCenter(panel)
+        }
+    }
 
+    /// Position panel on the screen where the mouse is, using saved relative offset if available.
+    private func positionRemembered(_ panel: NSPanel) {
         let hasSaved = UserDefaults.standard.object(forKey: "\(POSITION_KEY).rx") != nil
-        if hasSaved {
+        if hasSaved,
+           let screen = rememberedScreen() ?? NSScreen.screenWithMouse ?? NSScreen.main ?? NSScreen.screens.first {
+            let visibleFrame = screen.visibleFrame
             // Saved offset is relative to the screen's visible frame (0.0~1.0 ratio)
             let rx = UserDefaults.standard.double(forKey: "\(POSITION_KEY).rx")
             let ry = UserDefaults.standard.double(forKey: "\(POSITION_KEY).ry")
@@ -237,24 +266,114 @@ final class QuickPanelWindowController {
             let y = visibleFrame.origin.y + ry * visibleFrame.height
             panel.setFrameOrigin(NSPoint(x: x, y: y))
         } else {
+            let screen = NSScreen.screenWithMouse ?? NSScreen.main ?? NSScreen.screens.first
+            guard let screen else { return }
             centerOnScreen(panel, screen: screen)
         }
     }
 
+    private func rememberedScreen() -> NSScreen? {
+        let screenID = UserDefaults.standard.string(forKey: POSITION_SCREEN_KEY)
+        return ScreenLocator.screen(for: screenID)
+    }
+
     private func centerOnScreen(_ panel: NSPanel, screen: NSScreen) {
         let frame = screen.visibleFrame
-        let x = frame.midX - panelWidth / 2
-        let y = frame.midY - panelHeight / 2 + VERTICAL_OFFSET
+        let x = frame.midX - panel.frame.width / 2
+        let y = preferredUpperCenterY(screen: screen, panelHeight: panel.frame.height)
         panel.setFrameOrigin(NSPoint(x: x, y: y))
+    }
+
+    private func centerOnScreenExact(_ panel: NSPanel, screen: NSScreen) {
+        let frame = screen.visibleFrame
+        let x = frame.midX - panel.frame.width / 2
+        let y = frame.midY - panel.frame.height / 2
+        panel.setFrameOrigin(NSPoint(x: x, y: y))
+    }
+
+    private func positionAtCursor(_ panel: NSPanel) {
+        guard let screen = NSScreen.screenWithMouse ?? resolveTargetScreen() else { return }
+        let mouse = NSEvent.mouseLocation
+        let origin = CGPoint(
+            x: mouse.x - panel.frame.width / 2,
+            y: mouse.y - panel.frame.height / 2
+        )
+        setClampedOrigin(origin, for: panel, on: screen)
+    }
+
+    private func positionAtMenuBarIcon(_ panel: NSPanel) {
+        if let frame = MenuBarAnchorStore.shared.frameInScreen {
+            let center = CGPoint(x: frame.midX, y: frame.midY)
+            let screen = ScreenLocator.screen(containing: center)
+                ?? MenuBarAnchorStore.shared.screenID.flatMap(ScreenLocator.screen(for:))
+                ?? resolveTargetScreen()
+            guard let screen else { return }
+
+            let origin = CGPoint(
+                x: frame.midX - panel.frame.width / 2,
+                y: frame.minY - panel.frame.height - 8
+            )
+            setClampedOrigin(origin, for: panel, on: screen)
+            return
+        }
+
+        guard let screen = resolveTargetScreen() else { return }
+        centerOnScreenExact(panel, screen: screen)
+    }
+
+    private func positionAtWindowCenter(_ panel: NSPanel) {
+        if let frame = ActiveWindowLocator.focusedWindowFrame(),
+           let screen = ScreenLocator.screen(for: frame) {
+            let origin = CGPoint(
+                x: frame.midX - panel.frame.width / 2,
+                y: frame.midY - panel.frame.height / 2
+            )
+            setClampedOrigin(origin, for: panel, on: screen)
+            return
+        }
+
+        guard let screen = resolveTargetScreen() else { return }
+        centerOnScreenExact(panel, screen: screen)
+    }
+
+    private func positionAtScreenCenter(_ panel: NSPanel) {
+        guard let screen = resolveTargetScreen() else { return }
+        centerOnScreen(panel, screen: screen)
+    }
+
+    private func resolveTargetScreen() -> NSScreen? {
+        switch screenTarget {
+        case .active:
+            ActiveWindowLocator.activeScreen()
+        case .specified:
+            ScreenLocator.screen(for: specifiedScreenID)
+                ?? ActiveWindowLocator.activeScreen()
+                ?? NSScreen.screenWithMouse
+                ?? NSScreen.main
+                ?? NSScreen.screens.first
+        }
+    }
+
+    private func setClampedOrigin(_ origin: CGPoint, for panel: NSPanel, on screen: NSScreen) {
+        let clamped = clampedOrigin(origin, panelSize: panel.frame.size, visibleFrame: screen.visibleFrame)
+        panel.setFrameOrigin(clamped)
+    }
+
+    private func clampedOrigin(_ origin: CGPoint, panelSize: CGSize, visibleFrame: CGRect) -> CGPoint {
+        let maxX = max(visibleFrame.minX, visibleFrame.maxX - panelSize.width)
+        let maxY = max(visibleFrame.minY, visibleFrame.maxY - panelSize.height)
+        return CGPoint(
+            x: min(max(origin.x, visibleFrame.minX), maxX),
+            y: min(max(origin.y, visibleFrame.minY), maxY)
+        )
     }
 
     func resetPosition() {
         UserDefaults.standard.removeObject(forKey: "\(POSITION_KEY).rx")
         UserDefaults.standard.removeObject(forKey: "\(POSITION_KEY).ry")
+        UserDefaults.standard.removeObject(forKey: POSITION_SCREEN_KEY)
         guard let panel, panel.isVisible else { return }
-        let screen = NSScreen.screenWithMouse ?? NSScreen.main ?? NSScreen.screens.first
-        guard let screen else { return }
-        centerOnScreen(panel, screen: screen)
+        positionPanel(panel)
     }
 
     private func savePosition(_ panel: NSPanel) {
@@ -266,6 +385,7 @@ final class QuickPanelWindowController {
         let ry = (panel.frame.origin.y - visibleFrame.origin.y) / visibleFrame.height
         UserDefaults.standard.set(rx, forKey: "\(POSITION_KEY).rx")
         UserDefaults.standard.set(ry, forKey: "\(POSITION_KEY).ry")
+        UserDefaults.standard.set(ScreenLocator.identifier(for: screen), forKey: POSITION_SCREEN_KEY)
     }
 
     private func installClickOutsideMonitor() {
@@ -363,7 +483,13 @@ final class QuickPanelWindowController {
     }
 
     private func recommendedTopY(screen: NSScreen, panelHeight: CGFloat) -> CGFloat {
-        screen.visibleFrame.maxY - VERTICAL_OFFSET - panelHeight
+        preferredUpperCenterY(screen: screen, panelHeight: panelHeight)
+    }
+
+    private func preferredUpperCenterY(screen: NSScreen, panelHeight: CGFloat) -> CGFloat {
+        let visibleFrame = screen.visibleFrame
+        let topInset = visibleFrame.height * TOP_INSET_RATIO
+        return visibleFrame.maxY - topInset - panelHeight
     }
 
     private func handleWindowMove() {
@@ -388,7 +514,7 @@ final class QuickPanelWindowController {
         if showV, !snappedV { hapticFeedback(); snappedV = true }
         if !showV { snappedV = false }
 
-        let guideTopY = visibleFrame.maxY - VERTICAL_OFFSET
+        let guideTopY = visibleFrame.maxY - visibleFrame.height * TOP_INSET_RATIO
         updateSnapGuide(on: screen, horizontal: showH, verticalCenter: showV && !nearTop, recommendedTop: showV && nearTop, guideTopY: guideTopY)
     }
 

--- a/Sources/Views/Settings/SettingsView.swift
+++ b/Sources/Views/Settings/SettingsView.swift
@@ -225,7 +225,7 @@ struct PreferencesTab: View {
     @AppStorage("showLinkURL") private var showLinkURL = false
     @AppStorage("webPreviewEnabled") private var webPreviewEnabled = true
     @AppStorage("imageLinkPreviewEnabled") private var imageLinkPreviewEnabled = true
-    @AppStorage(QuickPanelPositionSettings.modeKey) private var quickPanelPositionMode = QuickPanelPositionMode.cursor.rawValue
+    @AppStorage(QuickPanelPositionSettings.modeKey) private var quickPanelPositionMode = QuickPanelPositionMode.screenCenter.rawValue
     @AppStorage(QuickPanelPositionSettings.screenTargetKey) private var quickPanelScreenTarget = QuickPanelScreenTarget.active.rawValue
     @AppStorage(QuickPanelPositionSettings.specifiedScreenIDKey) private var quickPanelSpecifiedScreenID = ""
     private let allRetentionOptions = [1, 3, 7, 14, 30, 60, 90, 180, 365]

--- a/Sources/Views/Settings/SettingsView.swift
+++ b/Sources/Views/Settings/SettingsView.swift
@@ -225,11 +225,21 @@ struct PreferencesTab: View {
     @AppStorage("showLinkURL") private var showLinkURL = false
     @AppStorage("webPreviewEnabled") private var webPreviewEnabled = true
     @AppStorage("imageLinkPreviewEnabled") private var imageLinkPreviewEnabled = true
+    @AppStorage(QuickPanelPositionSettings.modeKey) private var quickPanelPositionMode = QuickPanelPositionMode.remembered.rawValue
+    @AppStorage(QuickPanelPositionSettings.screenTargetKey) private var quickPanelScreenTarget = QuickPanelScreenTarget.active.rawValue
+    @AppStorage(QuickPanelPositionSettings.specifiedScreenIDKey) private var quickPanelSpecifiedScreenID = ""
     private let allRetentionOptions = [1, 3, 7, 14, 30, 60, 90, 180, 365]
 
     private var availableOptions: [Int] { allRetentionOptions }
 
     private var showForever: Bool { true }
+    private var screenOptions: [ScreenOption] { ScreenLocator.options() }
+    private var currentPositionMode: QuickPanelPositionMode {
+        QuickPanelPositionMode(rawValue: quickPanelPositionMode) ?? .remembered
+    }
+    private var currentScreenTarget: QuickPanelScreenTarget {
+        QuickPanelScreenTarget(rawValue: quickPanelScreenTarget) ?? .active
+    }
 
     var body: some View {
         Form {
@@ -294,6 +304,67 @@ struct PreferencesTab: View {
                 }
             }
 
+            Section(L10n.tr("settings.display")) {
+                HStack {
+                    Text(L10n.tr("settings.quickPanelPosition"))
+                    Spacer()
+                    Menu {
+                        positionMenuItem(
+                            title: L10n.tr(QuickPanelPositionMode.cursor.titleKey),
+                            isSelected: currentPositionMode == .cursor
+                        ) {
+                            selectQuickPanelPosition(.cursor)
+                        }
+
+                        positionMenuItem(
+                            title: L10n.tr(QuickPanelPositionMode.menuBarIcon.titleKey),
+                            isSelected: currentPositionMode == .menuBarIcon
+                        ) {
+                            selectQuickPanelPosition(.menuBarIcon)
+                        }
+
+                        positionMenuItem(
+                            title: L10n.tr(QuickPanelPositionMode.windowCenter.titleKey),
+                            isSelected: currentPositionMode == .windowCenter
+                        ) {
+                            selectQuickPanelPosition(.windowCenter)
+                        }
+
+                        Menu(L10n.tr(QuickPanelPositionMode.screenCenter.titleKey)) {
+                            positionMenuItem(
+                                title: L10n.tr("settings.quickPanelTargetScreen.active"),
+                                isSelected: currentPositionMode == .screenCenter && currentScreenTarget == .active
+                            ) {
+                                selectQuickPanelPosition(.screenCenter, screenTarget: .active)
+                            }
+
+                            ForEach(screenOptions) { screen in
+                                positionMenuItem(
+                                    title: screen.name,
+                                    isSelected: currentPositionMode == .screenCenter
+                                        && currentScreenTarget == .specified
+                                        && quickPanelSpecifiedScreenID == screen.id
+                                ) {
+                                    selectQuickPanelPosition(.screenCenter, screenTarget: .specified, screenID: screen.id)
+                                }
+                            }
+                        }
+
+                        positionMenuItem(
+                            title: L10n.tr(QuickPanelPositionMode.remembered.titleKey),
+                            isSelected: currentPositionMode == .remembered
+                        ) {
+                            selectQuickPanelPosition(.remembered)
+                        }
+                    } label: {
+                        Text(currentPositionTitle)
+                            .foregroundStyle(.primary)
+                    }
+                    .menuStyle(.borderlessButton)
+                    .fixedSize()
+                }
+            }
+
             Section(L10n.tr("settings.behavior")) {
                 Toggle(L10n.tr("settings.autoPaste"), isOn: $quickPanelAutoPaste)
                 Toggle(L10n.tr("settings.addNewLine"), isOn: $addNewLineAfterPaste)
@@ -336,6 +407,15 @@ struct PreferencesTab: View {
         } message: {
             Text(L10n.tr("settings.retentionDays.cleanWarning"))
         }
+        .onAppear {
+            ensureSpecifiedScreenSelection()
+        }
+        .onChange(of: quickPanelPositionMode) {
+            ensureSpecifiedScreenSelection()
+        }
+        .onChange(of: quickPanelScreenTarget) {
+            ensureSpecifiedScreenSelection()
+        }
     }
 
     private func applyShortcut() {
@@ -373,6 +453,60 @@ struct PreferencesTab: View {
             }
         }
         ClipItemStore.deleteAndNotify(expiredItems, from: modelContext)
+    }
+
+    private func ensureSpecifiedScreenSelection() {
+        guard currentScreenTarget == .specified else { return }
+        guard ScreenLocator.screen(for: quickPanelSpecifiedScreenID) == nil else { return }
+        quickPanelSpecifiedScreenID = screenOptions.first?.id ?? ""
+    }
+
+    private var currentPositionTitle: String {
+        switch currentPositionMode {
+        case .remembered:
+            return L10n.tr(QuickPanelPositionMode.remembered.titleKey)
+        case .cursor:
+            return L10n.tr(QuickPanelPositionMode.cursor.titleKey)
+        case .menuBarIcon:
+            return L10n.tr(QuickPanelPositionMode.menuBarIcon.titleKey)
+        case .windowCenter:
+            return L10n.tr(QuickPanelPositionMode.windowCenter.titleKey)
+        case .screenCenter:
+            switch currentScreenTarget {
+            case .active:
+                return "\(L10n.tr(QuickPanelPositionMode.screenCenter.titleKey)) (\(L10n.tr("settings.quickPanelTargetScreen.active")))"
+            case .specified:
+                let screenName = screenOptions.first(where: { $0.id == quickPanelSpecifiedScreenID })?.name
+                    ?? L10n.tr("settings.quickPanelSpecifiedScreen")
+                return "\(L10n.tr(QuickPanelPositionMode.screenCenter.titleKey)) (\(screenName))"
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func positionMenuItem(title: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            if isSelected {
+                Label(title, systemImage: "checkmark")
+            } else {
+                Text(title)
+            }
+        }
+    }
+
+    private func selectQuickPanelPosition(
+        _ mode: QuickPanelPositionMode,
+        screenTarget: QuickPanelScreenTarget = .active,
+        screenID: String? = nil
+    ) {
+        quickPanelPositionMode = mode.rawValue
+
+        if mode == .screenCenter {
+            quickPanelScreenTarget = screenTarget.rawValue
+            if screenTarget == .specified {
+                quickPanelSpecifiedScreenID = screenID ?? screenOptions.first?.id ?? ""
+            }
+        }
     }
 }
 

--- a/Sources/Views/Settings/SettingsView.swift
+++ b/Sources/Views/Settings/SettingsView.swift
@@ -225,7 +225,7 @@ struct PreferencesTab: View {
     @AppStorage("showLinkURL") private var showLinkURL = false
     @AppStorage("webPreviewEnabled") private var webPreviewEnabled = true
     @AppStorage("imageLinkPreviewEnabled") private var imageLinkPreviewEnabled = true
-    @AppStorage(QuickPanelPositionSettings.modeKey) private var quickPanelPositionMode = QuickPanelPositionMode.remembered.rawValue
+    @AppStorage(QuickPanelPositionSettings.modeKey) private var quickPanelPositionMode = QuickPanelPositionMode.cursor.rawValue
     @AppStorage(QuickPanelPositionSettings.screenTargetKey) private var quickPanelScreenTarget = QuickPanelScreenTarget.active.rawValue
     @AppStorage(QuickPanelPositionSettings.specifiedScreenIDKey) private var quickPanelSpecifiedScreenID = ""
     private let allRetentionOptions = [1, 3, 7, 14, 30, 60, 90, 180, 365]

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+MODULE_CACHE_DIR="$ROOT_DIR/.build/ModuleCache"
+TEMP_HOME_DIR="$ROOT_DIR/.tmp-home"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash ./scripts/check.sh [--all|--staged]
+
+Options:
+  --all       Check the whole repository scope
+  --staged    Check only staged files
+EOF
+}
+
+scope="all"
+if [[ $# -gt 1 ]]; then
+  usage >&2
+  exit 1
+fi
+
+if [[ $# -eq 1 ]]; then
+  case "$1" in
+    --all) scope="all" ;;
+    --staged) scope="staged" ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      exit 1
+      ;;
+  esac
+fi
+
+cd "$ROOT_DIR"
+mkdir -p "$MODULE_CACHE_DIR" "$TEMP_HOME_DIR"
+
+run_swift_eval() {
+  HOME="$TEMP_HOME_DIR" \
+  CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" \
+  swift -module-cache-path "$MODULE_CACHE_DIR" "$@"
+}
+
+run_swift_build() {
+  HOME="$TEMP_HOME_DIR" \
+  CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" \
+  swift build --disable-sandbox "$@"
+}
+
+collect_files() {
+  if [[ "$scope" == "staged" ]]; then
+    git rev-parse --git-dir >/dev/null 2>&1 || {
+      echo "[check] not a git repository" >&2
+      exit 1
+    }
+    git diff --cached --name-only --diff-filter=ACMR
+  else
+    git ls-files
+  fi
+}
+
+files=()
+while IFS= read -r line; do
+  files+=("$line")
+done < <(collect_files)
+
+if [[ ${#files[@]} -eq 0 ]]; then
+  echo "[check] no files to inspect"
+  exit 0
+fi
+
+swift_changed=false
+shell_files=()
+strings_files=()
+
+for file in "${files[@]}"; do
+  case "$file" in
+    Package.swift|Sources/*.swift|Sources/**/*.swift|Tests/*.swift|Tests/**/*.swift)
+      swift_changed=true
+      ;;
+  esac
+
+  case "$file" in
+    *.sh)
+      shell_files+=("$file")
+      ;;
+    *.strings)
+      strings_files+=("$file")
+      ;;
+  esac
+done
+
+run_count=0
+
+if [[ ${#shell_files[@]} -gt 0 ]]; then
+  echo "[check] bash syntax"
+  for file in "${shell_files[@]}"; do
+    bash -n "$file"
+  done
+  run_count=$((run_count + 1))
+fi
+
+if [[ ${#strings_files[@]} -gt 0 ]]; then
+  echo "[check] strings lint"
+  for file in "${strings_files[@]}"; do
+    run_swift_eval -e '
+import Foundation
+let path = CommandLine.arguments[1]
+let text = try String(contentsOfFile: path, encoding: .utf8)
+_ = (text as NSString).propertyListFromStringsFileFormat()
+' "$file" >/dev/null
+  done
+  run_count=$((run_count + 1))
+fi
+
+if [[ "$swift_changed" == true ]]; then
+  echo "[check] swift build"
+  run_swift_build
+  run_count=$((run_count + 1))
+fi
+
+if [[ $run_count -eq 0 ]]; then
+  echo "[check] no matching checks for current file set"
+else
+  echo "[check] done"
+fi

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+cd "$ROOT_DIR"
+
+git rev-parse --git-dir >/dev/null 2>&1 || {
+  echo "Not a git repository: $ROOT_DIR" >&2
+  exit 1
+}
+
+git config core.hooksPath .githooks
+echo "[hooks] core.hooksPath set to .githooks"

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -33,7 +33,8 @@ resolve_version() {
     fi
   fi
 
-  echo "VERSION is required. Example: make package VERSION=1.2.3" >&2
+  echo "VERSION is not set, and no git tag was found." >&2
+  echo "Use: make package VERSION=1.2.3" >&2
   exit 1
 }
 


### PR DESCRIPTION
- 新增快捷面板位置选项，支持 光标、菜单栏图标、活动窗口中心、屏幕居中偏上、记住上次位置
- 屏幕 支持活动屏幕和指定屏幕，记住上次位置 会同时记住屏幕
- 默认位置改为 光标，并简化了设置页的位置选择交互
- 新增 make check、make check-staged、make install-hooks，提交前可自动检查暂存区
- 修正打包脚本版本回退逻辑，并补充无 tag 时的明确提示