### PR TITLE
feat(shortcuts): scope manager hotkey to quick panel

### DIFF
--- a/Sources/Engine/HotkeyManager.swift
+++ b/Sources/Engine/HotkeyManager.swift
@@ -7,6 +7,7 @@ private let DEFAULT_MODIFIERS = cmdKey | shiftKey
 private let HOTKEY_ID_QUICK_PANEL: UInt32 = 1
 private let HOTKEY_ID_MANAGER: UInt32 = 2
 private let HOTKEY_ID_RELAY: UInt32 = 3
+private let MANAGER_HOTKEY_GLOBAL_ENABLED_KEY = "managerHotkeyGlobalEnabled"
 
 @MainActor
 final class HotkeyManager: ObservableObject {
@@ -71,9 +72,21 @@ final class HotkeyManager: ObservableObject {
         return stored
     }
 
+    var isManagerHotkeyGlobalEnabled: Bool {
+        guard UserDefaults.standard.object(forKey: MANAGER_HOTKEY_GLOBAL_ENABLED_KEY) != nil else { return true }
+        return UserDefaults.standard.bool(forKey: MANAGER_HOTKEY_GLOBAL_ENABLED_KEY)
+    }
+
     func updateManagerShortcut(keyCode: Int, modifiers: Int) {
         UserDefaults.standard.set(keyCode, forKey: "managerHotkeyKeyCode")
         UserDefaults.standard.set(modifiers, forKey: "managerHotkeyModifiers")
+        unregisterManagerHotKey()
+        registerManagerHotKey()
+        objectWillChange.send()
+    }
+
+    func updateManagerHotkeyGlobalEnabled(_ enabled: Bool) {
+        UserDefaults.standard.set(enabled, forKey: MANAGER_HOTKEY_GLOBAL_ENABLED_KEY)
         unregisterManagerHotKey()
         registerManagerHotKey()
         objectWillChange.send()
@@ -206,7 +219,7 @@ final class HotkeyManager: ObservableObject {
     }
 
     private func registerManagerHotKey() {
-        guard !isManagerCleared else { return }
+        guard isManagerHotkeyGlobalEnabled, !isManagerCleared else { return }
         var hotKeyID = EventHotKeyID()
         hotKeyID.signature = HOTKEY_SIGNATURE
         hotKeyID.id = HOTKEY_ID_MANAGER

--- a/Sources/Localization/de.lproj/Localizable.strings
+++ b/Sources/Localization/de.lproj/Localizable.strings
@@ -127,7 +127,9 @@
 "settings.features" = "Funktionen";
 "settings.shortcuts" = "Tastenkürzel";
 "settings.quickPanelShortcut" = "Schnelles Einfügen";
-"settings.managerShortcut" = "Open Manager";
+"settings.managerShortcut" = "Manager öffnen";
+"settings.managerShortcut.global" = "Global";
+"settings.managerShortcut.scopeHint" = "Wenn Global deaktiviert ist, funktioniert dieses Tastenkürzel nur, wenn das Schnellpanel bereits geöffnet ist.";
 "settings.relayShortcut" = "Relay starten";
 "settings.shortcut.none" = "Nicht festgelegt";
 "settings.paste" = "Einfügen";

--- a/Sources/Localization/en.lproj/Localizable.strings
+++ b/Sources/Localization/en.lproj/Localizable.strings
@@ -110,6 +110,8 @@
 "settings.shortcuts" = "Shortcuts";
 "settings.quickPanelShortcut" = "Quick Paste";
 "settings.managerShortcut" = "Open Manager";
+"settings.managerShortcut.global" = "Global";
+"settings.managerShortcut.scopeHint" = "When Global is off, this shortcut works only while the Quick Panel is already open.";
 "settings.relayShortcut" = "Start Relay";
 "settings.shortcut.none" = "Not set";
 "settings.shortcut.clickToRecord" = "Click to record";

--- a/Sources/Localization/es.lproj/Localizable.strings
+++ b/Sources/Localization/es.lproj/Localizable.strings
@@ -127,7 +127,9 @@
 "settings.features" = "Funciones";
 "settings.shortcuts" = "Atajos";
 "settings.quickPanelShortcut" = "Pegado rápido";
-"settings.managerShortcut" = "Open Manager";
+"settings.managerShortcut" = "Abrir gestor";
+"settings.managerShortcut.global" = "Global";
+"settings.managerShortcut.scopeHint" = "Cuando Global está desactivado, este atajo solo funciona mientras el panel rápido ya está abierto.";
 "settings.relayShortcut" = "Iniciar relevo";
 "settings.shortcut.none" = "No configurado";
 "settings.paste" = "Pegar";

--- a/Sources/Localization/fr.lproj/Localizable.strings
+++ b/Sources/Localization/fr.lproj/Localizable.strings
@@ -127,7 +127,9 @@
 "settings.features" = "Fonctionnalités";
 "settings.shortcuts" = "Raccourcis";
 "settings.quickPanelShortcut" = "Collage rapide";
-"settings.managerShortcut" = "Open Manager";
+"settings.managerShortcut" = "Ouvrir le gestionnaire";
+"settings.managerShortcut.global" = "Global";
+"settings.managerShortcut.scopeHint" = "Lorsque Global est désactivé, ce raccourci ne fonctionne que lorsque le panneau rapide est déjà ouvert.";
 "settings.relayShortcut" = "Démarrer le relais";
 "settings.shortcut.none" = "Non défini";
 "settings.paste" = "Collage";

--- a/Sources/Localization/id.lproj/Localizable.strings
+++ b/Sources/Localization/id.lproj/Localizable.strings
@@ -101,7 +101,9 @@
 "settings.features" = "Fitur";
 "settings.shortcuts" = "Pintasan";
 "settings.quickPanelShortcut" = "Tempel Cepat";
-"settings.managerShortcut" = "Open Manager";
+"settings.managerShortcut" = "Buka Pengelola";
+"settings.managerShortcut.global" = "Global";
+"settings.managerShortcut.scopeHint" = "Saat Global dimatikan, pintasan ini hanya berfungsi ketika panel cepat sudah terbuka.";
 "settings.relayShortcut" = "Mulai relay";
 "settings.shortcut.none" = "Belum diatur";
 "settings.shortcut.clickToRecord" = "Klik untuk merekam";

--- a/Sources/Localization/it.lproj/Localizable.strings
+++ b/Sources/Localization/it.lproj/Localizable.strings
@@ -101,7 +101,9 @@
 "settings.features" = "Funzionalità";
 "settings.shortcuts" = "Scorciatoie";
 "settings.quickPanelShortcut" = "Incolla Rapido";
-"settings.managerShortcut" = "Open Manager";
+"settings.managerShortcut" = "Apri Gestore";
+"settings.managerShortcut.global" = "Globale";
+"settings.managerShortcut.scopeHint" = "Quando Globale è disattivato, questa scorciatoia funziona solo mentre il pannello rapido è già aperto.";
 "settings.relayShortcut" = "Avvia staffetta";
 "settings.shortcut.none" = "Non impostata";
 "settings.shortcut.clickToRecord" = "Clicca per registrare";

--- a/Sources/Localization/ja.lproj/Localizable.strings
+++ b/Sources/Localization/ja.lproj/Localizable.strings
@@ -135,7 +135,9 @@
 "settings.features" = "機能";
 "settings.shortcuts" = "ショートカット";
 "settings.quickPanelShortcut" = "クイックペースト";
-"settings.managerShortcut" = "Open Manager";
+"settings.managerShortcut" = "管理ツールを開く";
+"settings.managerShortcut.global" = "グローバル";
+"settings.managerShortcut.scopeHint" = "グローバルをオフにすると、このショートカットはクイックパネルがすでに開いているときだけ使えます。";
 "settings.relayShortcut" = "リレー開始";
 "settings.shortcut.none" = "未設定";
 "settings.paste" = "ペースト";

--- a/Sources/Localization/ko.lproj/Localizable.strings
+++ b/Sources/Localization/ko.lproj/Localizable.strings
@@ -127,7 +127,9 @@
 "settings.features" = "기능";
 "settings.shortcuts" = "단축키";
 "settings.quickPanelShortcut" = "빠른 붙여넣기";
-"settings.managerShortcut" = "Open Manager";
+"settings.managerShortcut" = "관리자 열기";
+"settings.managerShortcut.global" = "전역";
+"settings.managerShortcut.scopeHint" = "전역을 끄면 이 단축키는 빠른 패널이 이미 열려 있을 때만 동작합니다.";
 "settings.relayShortcut" = "릴레이 시작";
 "settings.shortcut.none" = "미설정";
 "settings.paste" = "붙여넣기";

--- a/Sources/Localization/ru.lproj/Localizable.strings
+++ b/Sources/Localization/ru.lproj/Localizable.strings
@@ -101,7 +101,9 @@
 "settings.features" = "Функции";
 "settings.shortcuts" = "Горячие клавиши";
 "settings.quickPanelShortcut" = "Быстрая вставка";
-"settings.managerShortcut" = "Open Manager";
+"settings.managerShortcut" = "Открыть менеджер";
+"settings.managerShortcut.global" = "Глобально";
+"settings.managerShortcut.scopeHint" = "Когда глобальный режим выключен, это сочетание клавиш работает только если быстрая панель уже открыта.";
 "settings.relayShortcut" = "Начать эстафету";
 "settings.shortcut.none" = "Не задано";
 "settings.shortcut.clickToRecord" = "Нажмите для записи";

--- a/Sources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Localization/zh-Hans.lproj/Localizable.strings
@@ -110,6 +110,8 @@
 "settings.shortcuts" = "快捷键";
 "settings.quickPanelShortcut" = "打开快捷粘贴窗口";
 "settings.managerShortcut" = "打开管理器";
+"settings.managerShortcut.global" = "全局";
+"settings.managerShortcut.scopeHint" = "关闭全局后，这个快捷键只在快捷面板已打开时可用。";
 "settings.relayShortcut" = "开启接力";
 "settings.shortcut.none" = "未设置";
 "settings.shortcut.clickToRecord" = "点击录入";

--- a/Sources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Localization/zh-Hant.lproj/Localizable.strings
@@ -102,7 +102,9 @@
 "settings.features" = "功能";
 "settings.shortcuts" = "快捷鍵";
 "settings.quickPanelShortcut" = "開啟快捷貼上視窗";
-"settings.managerShortcut" = "Open Manager";
+"settings.managerShortcut" = "開啟管理器";
+"settings.managerShortcut.global" = "全域";
+"settings.managerShortcut.scopeHint" = "關閉全域後，這個快捷鍵只會在快捷面板已開啟時可用。";
 "settings.relayShortcut" = "開啟接力";
 "settings.shortcut.none" = "未設定";
 "settings.shortcut.clickToRecord" = "點擊錄入";

--- a/Sources/Views/MenuBar/MenuBarView.swift
+++ b/Sources/Views/MenuBar/MenuBarView.swift
@@ -24,7 +24,9 @@ struct MenuBarContent: View {
         Button {
             handleOpenMainWindow()
         } label: {
-            let shortcut = hotkeyManager.isManagerCleared ? "" : shortcutDisplayString(keyCode: hotkeyManager.managerKeyCode, modifiers: hotkeyManager.managerModifiers)
+            let shortcut = hotkeyManager.isManagerCleared || !hotkeyManager.isManagerHotkeyGlobalEnabled
+                ? ""
+                : shortcutDisplayString(keyCode: hotkeyManager.managerKeyCode, modifiers: hotkeyManager.managerModifiers)
             if shortcut.isEmpty {
                 Text(L10n.tr("menu.manager"))
             } else {

--- a/Sources/Views/Settings/SettingsView.swift
+++ b/Sources/Views/Settings/SettingsView.swift
@@ -215,6 +215,7 @@ struct ShortcutsTab: View {
     @AppStorage("hotkeyModifiers") private var hotkeyModifiers = cmdKey | shiftKey
     @AppStorage("managerHotkeyKeyCode") private var managerKeyCode = -1
     @AppStorage("managerHotkeyModifiers") private var managerModifiers = -1
+    @AppStorage("managerHotkeyGlobalEnabled") private var managerHotkeyGlobalEnabled = true
     @AppStorage("relayHotkeyKeyCode") private var relayKeyCode = -1
     @AppStorage("relayHotkeyModifiers") private var relayModifiers = -1
     @AppStorage("doubleTapEnabled") private var doubleTapEnabled = false
@@ -253,6 +254,19 @@ struct ShortcutsTab: View {
                             .foregroundStyle(.tertiary)
                             .font(.callout)
                     }
+                    HStack(spacing: 6) {
+                        Text(L10n.tr("settings.managerShortcut.global"))
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                        Toggle("", isOn: $managerHotkeyGlobalEnabled)
+                            .labelsHidden()
+                            .toggleStyle(.switch)
+                            .controlSize(.small)
+                            .fixedSize()
+                            .onChange(of: managerHotkeyGlobalEnabled) {
+                                hotkeyManager.updateManagerHotkeyGlobalEnabled(managerHotkeyGlobalEnabled)
+                            }
+                    }
                     ShortcutRecorder(keyCode: $managerKeyCode, modifiers: $managerModifiers, onChanged: applyManagerShortcut)
                         .frame(width: 140, height: 24)
                     Button {
@@ -266,6 +280,10 @@ struct ShortcutsTab: View {
                     .buttonStyle(.plain)
                     .pointerCursor()
                 }
+
+                Text(L10n.tr("settings.managerShortcut.scopeHint"))
+                    .font(.callout)
+                    .foregroundStyle(.tertiary)
 
                 HStack {
                     Text(L10n.tr("settings.relayShortcut"))


### PR DESCRIPTION
设置页为“打开管理器”快捷键增加“全局”开关,关闭后仅在quick panel 中可用,用以快速从quick panel 打开管理器主界面