### PR TITLE
feat(settings): add confirmation option for single item deletion

### DIFF
--- a/Sources/Localization/de.lproj/Localizable.strings
+++ b/Sources/Localization/de.lproj/Localizable.strings
@@ -142,6 +142,7 @@
 "settings.autoPaste" = "Mit Enter direkt in App einfügen";
 "settings.addNewLine" = "Nach dem Einfügen neue Zeile hinzufügen";
 "settings.quickPanelLaunchAnimation" = "Startanimation des Schnellpanels";
+"settings.confirmSingleDelete" = "Confirm before deleting a single item";
 "settings.quickPanelSecondaryRow" = "Unter der Schnellpanel-Suche anzeigen";
 "settings.quickPanelSecondaryRow.types" = "Typen";
 "settings.quickPanelSecondaryRow.groups" = "Gruppen";

--- a/Sources/Localization/en.lproj/Localizable.strings
+++ b/Sources/Localization/en.lproj/Localizable.strings
@@ -122,6 +122,7 @@
 "settings.autoPaste" = "Paste to App on Enter";
 "settings.addNewLine" = "Add new line after paste";
 "settings.quickPanelLaunchAnimation" = "Quick Panel launch animation";
+"settings.confirmSingleDelete" = "Confirm before deleting a single item";
 "settings.quickPanelSecondaryRow" = "Show below Quick Panel search";
 "settings.quickPanelSecondaryRow.types" = "Types";
 "settings.quickPanelSecondaryRow.groups" = "Groups";

--- a/Sources/Localization/es.lproj/Localizable.strings
+++ b/Sources/Localization/es.lproj/Localizable.strings
@@ -142,6 +142,7 @@
 "settings.autoPaste" = "Pegar en la app con Enter";
 "settings.addNewLine" = "Agregar nueva línea después de pegar";
 "settings.quickPanelLaunchAnimation" = "Animación de apertura del panel rápido";
+"settings.confirmSingleDelete" = "Confirm before deleting a single item";
 "settings.quickPanelSecondaryRow" = "Mostrar debajo de la búsqueda del panel rápido";
 "settings.quickPanelSecondaryRow.types" = "Tipos";
 "settings.quickPanelSecondaryRow.groups" = "Grupos";

--- a/Sources/Localization/fr.lproj/Localizable.strings
+++ b/Sources/Localization/fr.lproj/Localizable.strings
@@ -142,6 +142,7 @@
 "settings.autoPaste" = "Coller dans l'app avec Entrée";
 "settings.addNewLine" = "Ajouter un retour à la ligne après le collage";
 "settings.quickPanelLaunchAnimation" = "Animation de lancement du panneau rapide";
+"settings.confirmSingleDelete" = "Confirm before deleting a single item";
 "settings.quickPanelSecondaryRow" = "Afficher sous la recherche du panneau rapide";
 "settings.quickPanelSecondaryRow.types" = "Types";
 "settings.quickPanelSecondaryRow.groups" = "Groupes";

--- a/Sources/Localization/id.lproj/Localizable.strings
+++ b/Sources/Localization/id.lproj/Localizable.strings
@@ -112,6 +112,7 @@
 "settings.autoPaste" = "Tempel ke app dengan Enter";
 "settings.addNewLine" = "Tambah baris baru setelah tempel";
 "settings.quickPanelLaunchAnimation" = "Animasi peluncuran panel cepat";
+"settings.confirmSingleDelete" = "Confirm before deleting a single item";
 "settings.quickPanelSecondaryRow" = "Tampilkan di bawah pencarian panel cepat";
 "settings.quickPanelSecondaryRow.types" = "Tipe";
 "settings.quickPanelSecondaryRow.groups" = "Grup";

--- a/Sources/Localization/it.lproj/Localizable.strings
+++ b/Sources/Localization/it.lproj/Localizable.strings
@@ -112,6 +112,7 @@
 "settings.autoPaste" = "Incolla nell'app con Invio";
 "settings.addNewLine" = "Aggiungi a capo dopo incolla";
 "settings.quickPanelLaunchAnimation" = "Animazione di avvio del pannello rapido";
+"settings.confirmSingleDelete" = "Confirm before deleting a single item";
 "settings.quickPanelSecondaryRow" = "Mostra sotto la ricerca del pannello rapido";
 "settings.quickPanelSecondaryRow.types" = "Tipi";
 "settings.quickPanelSecondaryRow.groups" = "Gruppi";

--- a/Sources/Localization/ja.lproj/Localizable.strings
+++ b/Sources/Localization/ja.lproj/Localizable.strings
@@ -150,6 +150,7 @@
 "settings.autoPaste" = "Enterでアプリに直接ペースト";
 "settings.addNewLine" = "ペースト後に改行を追加";
 "settings.quickPanelLaunchAnimation" = "クイックパネル起動アニメーション";
+"settings.confirmSingleDelete" = "Confirm before deleting a single item";
 "settings.quickPanelSecondaryRow" = "クイックパネル検索下に表示";
 "settings.quickPanelSecondaryRow.types" = "タイプ";
 "settings.quickPanelSecondaryRow.groups" = "グループ";

--- a/Sources/Localization/ko.lproj/Localizable.strings
+++ b/Sources/Localization/ko.lproj/Localizable.strings
@@ -142,6 +142,7 @@
 "settings.autoPaste" = "Enter로 앱에 바로 붙여넣기";
 "settings.addNewLine" = "붙여넣기 후 줄바꿈 추가";
 "settings.quickPanelLaunchAnimation" = "빠른 패널 실행 애니메이션";
+"settings.confirmSingleDelete" = "Confirm before deleting a single item";
 "settings.quickPanelSecondaryRow" = "빠른 패널 검색 아래에 표시";
 "settings.quickPanelSecondaryRow.types" = "유형";
 "settings.quickPanelSecondaryRow.groups" = "그룹";

--- a/Sources/Localization/ru.lproj/Localizable.strings
+++ b/Sources/Localization/ru.lproj/Localizable.strings
@@ -112,6 +112,7 @@
 "settings.autoPaste" = "Вставлять в приложение по Enter";
 "settings.addNewLine" = "Добавлять перевод строки после вставки";
 "settings.quickPanelLaunchAnimation" = "Анимация запуска быстрой панели";
+"settings.confirmSingleDelete" = "Confirm before deleting a single item";
 "settings.quickPanelSecondaryRow" = "Показывать под поиском быстрой панели";
 "settings.quickPanelSecondaryRow.types" = "Типы";
 "settings.quickPanelSecondaryRow.groups" = "Группы";

--- a/Sources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Localization/zh-Hans.lproj/Localizable.strings
@@ -122,6 +122,7 @@
 "settings.autoPaste" = "回车直接粘贴到应用";
 "settings.addNewLine" = "粘贴后自动换行";
 "settings.quickPanelLaunchAnimation" = "快捷面板启动动画";
+"settings.confirmSingleDelete" = "删除单条记录前确认";
 "settings.quickPanelSecondaryRow" = "快捷面板搜索框下方显示";
 "settings.quickPanelSecondaryRow.types" = "类型";
 "settings.quickPanelSecondaryRow.groups" = "分组";

--- a/Sources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Localization/zh-Hant.lproj/Localizable.strings
@@ -113,6 +113,7 @@
 "settings.autoPaste" = "按 Enter 直接貼上到應用";
 "settings.addNewLine" = "貼上後自動換行";
 "settings.quickPanelLaunchAnimation" = "快捷面板啟動動畫";
+"settings.confirmSingleDelete" = "刪除單條記錄前確認";
 "settings.quickPanelSecondaryRow" = "快捷面板搜尋框下方顯示";
 "settings.quickPanelSecondaryRow.types" = "類型";
 "settings.quickPanelSecondaryRow.groups" = "分組";

--- a/Sources/Views/Main/MainWindowView.swift
+++ b/Sources/Views/Main/MainWindowView.swift
@@ -58,6 +58,7 @@ struct MainWindowView: View {
     @State private var cachedVisualOrderedItems: [ClipItem] = []
     @AppStorage("hideDockIcon") private var hideDockIcon = false
     @AppStorage("alwaysOnTop") private var alwaysOnTop = false
+    @AppStorage("confirmSingleDelete") private var confirmSingleDelete = true
 
     private var sourceApps: [String] { store.sourceApps }
 
@@ -1233,12 +1234,14 @@ struct MainWindowView: View {
         let idsToDelete = selectedItems.intersection(visibleIDs)
         guard !idsToDelete.isEmpty else { return }
 
-        let alert = NSAlert()
-        alert.messageText = L10n.tr("action.deleteSelected.confirm", idsToDelete.count)
-        alert.alertStyle = .warning
-        alert.addButton(withTitle: L10n.tr("action.delete"))
-        alert.addButton(withTitle: L10n.tr("action.cancel"))
-        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        if idsToDelete.count > 1 || confirmSingleDelete {
+            let alert = NSAlert()
+            alert.messageText = L10n.tr("action.deleteSelected.confirm", idsToDelete.count)
+            alert.alertStyle = .warning
+            alert.addButton(withTitle: L10n.tr("action.delete"))
+            alert.addButton(withTitle: L10n.tr("action.cancel"))
+            guard alert.runModal() == .alertFirstButtonReturn else { return }
+        }
 
         // Find the lowest index among deleted items for successor selection
         let firstDeletedIdx = items.firstIndex { idsToDelete.contains($0.persistentModelID) }

--- a/Sources/Views/QuickPanel/QuickPanelView.swift
+++ b/Sources/Views/QuickPanel/QuickPanelView.swift
@@ -58,6 +58,7 @@ struct QuickPanelView: View {
     @State private var cachedItemMap: [PersistentIdentifier: ClipItem] = [:]
     @State private var cachedIDSet: Set<PersistentIdentifier> = []
     @AppStorage("quickPanelAutoPaste") private var quickPanelAutoPaste = true
+    @AppStorage("confirmSingleDelete") private var confirmSingleDelete = true
     @AppStorage(QuickPanelSettings.secondaryRowKey) private var quickPanelSecondaryRowRaw = QuickPanelSecondaryRow.types.rawValue
 
     private var secondaryRow: QuickPanelSecondaryRow {
@@ -1803,6 +1804,14 @@ struct QuickPanelView: View {
 
     private func deleteItems(_ itemsToDelete: [ClipItem]) {
         guard !itemsToDelete.isEmpty else { return }
+        if itemsToDelete.count == 1 && confirmSingleDelete {
+            let alert = NSAlert()
+            alert.messageText = L10n.tr("action.deleteSelected.confirm", 1)
+            alert.alertStyle = .warning
+            alert.addButton(withTitle: L10n.tr("action.delete"))
+            alert.addButton(withTitle: L10n.tr("action.cancel"))
+            guard alert.runModal() == .alertFirstButtonReturn else { return }
+        }
         let items = filteredItems
         let idsToDelete = Set(itemsToDelete.map(\.persistentModelID))
         let firstIdx = items.firstIndex { idsToDelete.contains($0.persistentModelID) }

--- a/Sources/Views/Settings/SettingsView.swift
+++ b/Sources/Views/Settings/SettingsView.swift
@@ -353,6 +353,7 @@ struct PreferencesTab: View {
     @AppStorage("showLinkURL") private var showLinkURL = false
     @AppStorage("webPreviewEnabled") private var webPreviewEnabled = true
     @AppStorage("imageLinkPreviewEnabled") private var imageLinkPreviewEnabled = true
+    @AppStorage("confirmSingleDelete") private var confirmSingleDelete = true
     @AppStorage(QuickPanelSettings.launchAnimationEnabledKey) private var quickPanelLaunchAnimationEnabled = true
     @AppStorage(QuickPanelSettings.secondaryRowKey) private var quickPanelSecondaryRow = QuickPanelSecondaryRow.types.rawValue
     @AppStorage(QuickPanelPositionSettings.modeKey) private var quickPanelPositionMode = QuickPanelPositionMode.screenCenter.rawValue
@@ -444,6 +445,7 @@ struct PreferencesTab: View {
                 Toggle(L10n.tr("settings.autoPaste"), isOn: $quickPanelAutoPaste)
                 Toggle(L10n.tr("settings.addNewLine"), isOn: $addNewLineAfterPaste)
                 Toggle(L10n.tr("settings.quickPanelLaunchAnimation"), isOn: $quickPanelLaunchAnimationEnabled)
+                Toggle(L10n.tr("settings.confirmSingleDelete"), isOn: $confirmSingleDelete)
                 Toggle(L10n.tr("settings.showLinkURL"), isOn: $showLinkURL)
                 Toggle(L10n.tr("settings.webPreview"), isOn: $webPreviewEnabled)
                 Toggle(L10n.tr("settings.imageLinkPreview"), isOn: $imageLinkPreviewEnabled)


### PR DESCRIPTION
Introduced a new setting to confirm before deleting a single item, enhancing user control over deletions. This feature is reflected in the UI and localized across multiple languages.