### PR TITLE
修复超长 base64 图片预览卡顿

### DIFF
--- a/Sources/Engine/DataImageURI.swift
+++ b/Sources/Engine/DataImageURI.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+enum DataImageURI {
+    static let maxDecodedImageBytes = 20 * 1024 * 1024
+
+    static func isDataImageURI(_ text: String) -> Bool {
+        guard let start = firstNonWhitespaceIndex(in: text) else { return false }
+        return text[start...].hasPrefix("data:image/")
+    }
+
+    static func isBase64DataImageURI(_ text: String) -> Bool {
+        guard let header = dataImageHeader(in: text) else { return false }
+        return header.localizedCaseInsensitiveContains(";base64")
+    }
+
+    static func decodedImageData(from text: String, maxDecodedBytes: Int = maxDecodedImageBytes) -> Data? {
+        guard let payload = dataImagePayload(in: text),
+              let commaIndex = payload.firstIndex(of: ",") else { return nil }
+        let header = payload[..<commaIndex]
+        guard header.localizedCaseInsensitiveContains(";base64") else { return nil }
+
+        let base64Slice = payload[payload.index(after: commaIndex)...]
+        let estimatedBytes = (base64Slice.utf8.count * 3) / 4
+        guard estimatedBytes <= maxDecodedBytes else { return nil }
+
+        return Data(base64Encoded: String(base64Slice), options: .ignoreUnknownCharacters)
+    }
+
+    private static func dataImageHeader(in text: String) -> String.SubSequence? {
+        guard let payload = dataImagePayload(in: text),
+              let commaIndex = payload.firstIndex(of: ",") else { return nil }
+        return payload[..<commaIndex]
+    }
+
+    private static func dataImagePayload(in text: String) -> String.SubSequence? {
+        guard let start = firstNonWhitespaceIndex(in: text) else { return nil }
+        let payload = text[start...]
+        guard payload.hasPrefix("data:image/") else { return nil }
+        return payload
+    }
+
+    private static func firstNonWhitespaceIndex(in text: String) -> String.Index? {
+        text.firstIndex { !$0.isWhitespace }
+    }
+}

--- a/Sources/Views/Components/ClipRow.swift
+++ b/Sources/Views/Components/ClipRow.swift
@@ -11,6 +11,7 @@ struct ClipRow: View {
     var searchText: String = ""
     @AppStorage(OCRTaskCoordinator.enableOCRKey) private var ocrEnabled = true
     @AppStorage("imageLinkPreviewEnabled") private var imageLinkPreviewEnabled = true
+    @State private var dataURIThumbnailImage: NSImage?
 
     var body: some View {
         if item.isDeleted {
@@ -82,15 +83,32 @@ struct ClipRow: View {
                 .clipShape(RoundedRectangle(cornerRadius: 6))
                 .overlay(alignment: .bottomTrailing) { imageFormatBadge }
         } else if item.contentType == .link, imageLinkPreviewEnabled,
+                  DataImageURI.isBase64DataImageURI(item.content) {
+            Group {
+                if let img = dataURIThumbnailImage {
+                    Image(nsImage: img)
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .frame(width: 36, height: 36)
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                } else {
+                    linkFaviconThumbnail
+                }
+            }
+            .task(id: item.itemID) {
+                dataURIThumbnailImage = nil
+                let content = item.content
+                let data = await Task.detached(priority: .userInitiated) {
+                    DataImageURI.decodedImageData(from: content)
+                }.value
+                guard !Task.isCancelled,
+                      let data,
+                      let image = NSImage(data: data) else { return }
+                dataURIThumbnailImage = image
+            }
+        } else if item.contentType == .link, imageLinkPreviewEnabled,
                   LinkMetadataFetcher.isImageURL(item.content) {
-            if let img = Self.decodeDataURIImage(item.content) {
-                Image(nsImage: img)
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .frame(width: 36, height: 36)
-                    .clipShape(RoundedRectangle(cornerRadius: 6))
-                    .overlay(alignment: .bottomTrailing) { imageFormatBadge }
-            } else if let url = URL(string: item.content) {
+            if let url = URL(string: item.content) {
                 AsyncImage(url: url) { phase in
                     switch phase {
                     case .success(let image):
@@ -370,15 +388,6 @@ struct ClipRow: View {
     private func isDirectory(_ path: String) -> Bool {
         var isDir: ObjCBool = false
         return FileManager.default.fileExists(atPath: path, isDirectory: &isDir) && isDir.boolValue
-    }
-
-    private static func decodeDataURIImage(_ content: String) -> NSImage? {
-        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmed.hasPrefix("data:image/"),
-              let commaIndex = trimmed.firstIndex(of: ",") else { return nil }
-        let base64String = String(trimmed[trimmed.index(after: commaIndex)...])
-        guard let data = Data(base64Encoded: base64String, options: .ignoreUnknownCharacters) else { return nil }
-        return NSImage(data: data)
     }
 
     private var isMultiFile: Bool {

--- a/Sources/Views/QuickPanel/QuickPreviewPane.swift
+++ b/Sources/Views/QuickPanel/QuickPreviewPane.swift
@@ -9,6 +9,7 @@ struct QuickPreviewPane: View {
     @State private var allowHeavyPreview = false
     @State private var webPreviewReady = false
     @State private var cachedCodeSummary: CodePreviewSummary?
+    @State private var dataURIImageData: Data?
 
     struct CodePreviewSummary: Equatable {
         let language: CodeLanguage
@@ -105,6 +106,7 @@ struct QuickPreviewPane: View {
             allowHeavyPreview = false
             webPreviewReady = false
             cachedCodeSummary = nil
+            dataURIImageData = nil
             retryLinkMetadataIfNeeded()
 
             if item.contentType == .code {
@@ -121,6 +123,16 @@ struct QuickPreviewPane: View {
             try? await Task.sleep(for: heavyPreviewDelay)
             guard !Task.isCancelled else { return }
             allowHeavyPreview = true
+
+            if item.contentType == .link,
+               shouldRenderBase64DataImagePreview {
+                let content = item.content
+                let decoded = await Task.detached(priority: .userInitiated) {
+                    DataImageURI.decodedImageData(from: content)
+                }.value
+                guard !Task.isCancelled else { return }
+                dataURIImageData = decoded
+            }
         }
         } // zombie-object guard: isDeleted alone is unsafe after deleteAndNotify — see QuickPanelView.swift
     }
@@ -408,9 +420,10 @@ struct QuickPreviewPane: View {
 
     @ViewBuilder
     private var linkPreview: some View {
-        let trimmed = item.content.trimmingCharacters(in: .whitespacesAndNewlines)
-        if let url = URL(string: trimmed) {
-            let webviewActive = ((imageLinkPreviewEnabled && LinkMetadataFetcher.isImageURL(trimmed)) || webPreviewEnabled) && allowHeavyPreview
+        if shouldRenderBase64DataImagePreview {
+            dataURIImagePreview
+        } else if let url = URL(string: item.content.trimmingCharacters(in: .whitespacesAndNewlines)) {
+            let webviewActive = ((imageLinkPreviewEnabled && LinkMetadataFetcher.isImageURL(item.content)) || webPreviewEnabled) && allowHeavyPreview
             if webviewActive {
                 ZStack {
                     // WebView 始终驻留，加载完成前透明
@@ -455,6 +468,22 @@ struct QuickPreviewPane: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .padding(14)
         }
+    }
+
+    private var shouldRenderBase64DataImagePreview: Bool {
+        DataImageURI.isBase64DataImageURI(item.content) && (imageLinkPreviewEnabled || webPreviewEnabled)
+    }
+
+    private var dataURIImagePreview: some View {
+        AsyncPreviewImageView(
+            data: dataURIImageData,
+            cacheKey: "data-uri-\(item.itemID)",
+            maxPixelSize: 1100,
+            cornerRadius: 6,
+            thumbnailSize: 180
+        )
+        .padding(10)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     // MARK: - Link Static Preview
@@ -657,6 +686,7 @@ struct QuickPreviewPane: View {
 
     private func retryLinkMetadataIfNeeded() {
         guard item.contentType == .link,
+              !DataImageURI.isDataImageURI(item.content),
               item.linkTitle == nil,
               let context = item.modelContext,
               let _ = URL(string: item.content.trimmingCharacters(in: .whitespacesAndNewlines))

--- a/Tests/PasteMemoTests.swift
+++ b/Tests/PasteMemoTests.swift
@@ -544,6 +544,33 @@ struct PasteMemoTests {
         #expect(QuickPreviewPane.displayPath(for: url) == "/docs/page?ref=abc&lang=en")
     }
 
+    @Test("Data image URI helper detects and decodes base64 image payloads")
+    func dataImageURIHelperDecodesPayload() throws {
+        let png1x1 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lQn4NwAAAABJRU5ErkJggg=="
+        let uri = "  data:image/png;base64,\(png1x1)"
+
+        #expect(DataImageURI.isDataImageURI(uri))
+        #expect(DataImageURI.isBase64DataImageURI(uri))
+        let data = try #require(DataImageURI.decodedImageData(from: uri))
+        #expect(data.starts(with: [0x89, 0x50, 0x4E, 0x47]))
+    }
+
+    @Test("Data image URI helper keeps non-base64 image payloads out of decode path")
+    func dataImageURIHelperDistinguishesNonBase64Payloads() {
+        let uri = "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"
+
+        #expect(DataImageURI.isDataImageURI(uri))
+        #expect(!DataImageURI.isBase64DataImageURI(uri))
+        #expect(DataImageURI.decodedImageData(from: uri) == nil)
+    }
+
+    @Test("Data image URI helper refuses payloads above decoded byte cap")
+    func dataImageURIHelperHonorsDecodedByteCap() {
+        let uri = "data:image/png;base64,QUJDRA=="
+
+        #expect(DataImageURI.decodedImageData(from: uri, maxDecodedBytes: 2) == nil)
+    }
+
     @Test("OCR language list prioritizes Chinese when app language is Chinese")
     func ocrLanguagePriorityForChinese() {
         let languages = ImageOCRService.preferredRecognitionLanguages(appLanguage: "zh-Hans")


### PR DESCRIPTION
base64 图片改为后台解码并限制大小
非 base64 data image 保留原预览路径
预览逻辑继续遵守用户开关