### PR TITLE
feat(mcp): add clipboard_select_item and ui_show_quick_panel tools

### DIFF
--- a/Sources/Bridge/MCPInstructions.swift
+++ b/Sources/Bridge/MCPInstructions.swift
@@ -19,6 +19,8 @@ PasteMemo 剪贴板桥 — AI Agent 使用说明
 - clipboard_get                —— 按 ID 取单条全量内容（含 OCR 文字、图片字节等）
 - clipboard_list_recent_apps   —— 最近活跃来源 App 列表（用来反查 bundle ID）
 - clipboard_set                —— 写入剪贴板（写入会被标记为 AI Agent 来源）
+- clipboard_select_item      —— 将历史条目载入系统剪贴板（标记为 PasteMemo 自身写入，不产生重复历史、不重排序）
+- ui_show_quick_panel       —— 打开快捷粘贴面板（当用户想浏览剪贴板历史时使用）
 
 ## 工作流
 
@@ -32,7 +34,7 @@ PasteMemo 剪贴板桥 — AI Agent 使用说明
 
 ## 找很久之前的记录
 
-- search 默认按时间倒序，单次最多 100 条
+- search 默认按 lastUsedAt 倒序（与快捷面板排序一致），单次最多 100 条
 - 往回翻：用 since + until 组成时间窗口，把 until 设为上一批最老一条的
   created_at，继续翻
 - total 字段是窗口内的总匹配数（已应用所有过滤 + 隐私）

--- a/Sources/Bridge/MCPRequestRouter.swift
+++ b/Sources/Bridge/MCPRequestRouter.swift
@@ -15,13 +15,15 @@ final class MCPClientContext: @unchecked Sendable {
 final class MCPRequestRouter {
     private let container: ModelContainer
 
-    /// 5 个工具的注册表
+    /// 7 个工具的注册表
     private let tools: [String: any MCPTool] = [
         "clipboard_get_current":      GetCurrentTool(),
         "clipboard_search":           SearchHistoryTool(),
         "clipboard_get":              GetItemTool(),
         "clipboard_list_recent_apps": ListRecentAppsTool(),
         "clipboard_set":              SetClipboardTool(),
+        "clipboard_select_item":      PreparePasteTool(),
+        "ui_show_quick_panel":        ShowQuickPanelTool(),
     ]
 
     private let toolDescriptors: [MCPToolDescriptor] = [
@@ -30,6 +32,8 @@ final class MCPRequestRouter {
         GetItemTool.descriptor,
         ListRecentAppsTool.descriptor,
         SetClipboardTool.descriptor,
+        PreparePasteTool.descriptor,
+        ShowQuickPanelTool.descriptor,
     ]
 
     init(container: ModelContainer) {

--- a/Sources/Bridge/MCPTools/PreparePasteTool.swift
+++ b/Sources/Bridge/MCPTools/PreparePasteTool.swift
@@ -1,0 +1,50 @@
+import Foundation
+import SwiftData
+
+@MainActor
+struct PreparePasteTool: MCPTool {
+    struct Output: Codable {
+        let written: Bool
+        let item_id: String
+    }
+
+    static var descriptor: MCPToolDescriptor {
+        MCPToolDescriptor(
+            name: "clipboard_select_item",
+            description: "Load an existing clipboard history item onto the system pasteboard "
+                + "so the user can paste it with Cmd+V. Unlike clipboard_set, this reuses "
+                + "PasteMemo's internal paste writer and self-write marker, so it does not "
+                + "create a duplicate history entry or reorder existing items.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "id": .object(["type": .string("string")])
+                ]),
+                "required": .array([.string("id")])
+            ])
+        )
+    }
+
+    func call(
+        params: JSONValue?,
+        container: ModelContainer,
+        guardLayer: PrivacyGuard,
+        clientName: String? = nil
+    ) async throws -> JSONValue {
+        guard let id = params?.objectValue?["id"]?.stringValue else {
+            throw MCPToolError.invalidParams("missing 'id'")
+        }
+
+        let context = container.mainContext
+        let allItems = try context.fetch(FetchDescriptor<ClipItem>())
+        guard let item = allItems.first(where: { $0.itemID == id }) else {
+            throw MCPToolError.toolError("Item not found: \(id)")
+        }
+        guard guardLayer.filter([item]).first != nil else {
+            throw MCPToolError.toolError("Item not found: \(id)")
+        }
+
+        ClipboardManager.shared.writeToPasteboard(item)
+        return try MCPToolResult.textJSON(Output(written: true, item_id: item.itemID))
+    }
+}

--- a/Sources/Bridge/MCPTools/SearchHistoryTool.swift
+++ b/Sources/Bridge/MCPTools/SearchHistoryTool.swift
@@ -66,7 +66,10 @@ struct SearchHistoryTool: MCPTool {
         // SwiftData predicate 对 enum/可选捕获支持有限,沿用内存过滤;对 1036 量级的真实数据足够,
         // 大体量场景由 total_capped + since/until 时间窗口翻页解决。
         var descriptor = FetchDescriptor<ClipItem>(
-            sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
+            sortBy: [
+                SortDescriptor(\.lastUsedAt, order: .reverse),
+                SortDescriptor(\.createdAt, order: .reverse),
+            ]
         )
         descriptor.fetchLimit = Self.safetyCap
         var items = try context.fetch(descriptor)

--- a/Sources/Bridge/MCPTools/ShowQuickPanelTool.swift
+++ b/Sources/Bridge/MCPTools/ShowQuickPanelTool.swift
@@ -1,0 +1,31 @@
+import Foundation
+import SwiftData
+
+@MainActor
+struct ShowQuickPanelTool: MCPTool {
+    struct Output: Codable {
+        let opened: Bool
+    }
+
+    static var descriptor: MCPToolDescriptor {
+        MCPToolDescriptor(
+            name: "ui_show_quick_panel",
+            description: "Open the Quick Paste panel so the user can browse and paste from clipboard history. Use when the user asks to see their clipboard history or open the quick paste menu.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([:])
+            ])
+        )
+    }
+
+    func call(
+        params: JSONValue?,
+        container: ModelContainer,
+        guardLayer: PrivacyGuard,
+        clientName: String? = nil
+    ) async throws -> JSONValue {
+        DiagnosticLog.log("INVOKE ui_show_quick_panel MCP tool")
+        HotkeyManager.shared.showQuickPanel()
+        return try MCPToolResult.textJSON(Output(opened: true))
+    }
+}

--- a/Tests/BridgeTests/MCPRouterTests.swift
+++ b/Tests/BridgeTests/MCPRouterTests.swift
@@ -33,7 +33,7 @@ final class MCPRouterTests: XCTestCase {
         XCTAssertEqual(context.clientName, "claude-code")
     }
 
-    func testToolsListReturnsAll5Tools() async throws {
+    func testToolsListReturnsRegisteredTools() async throws {
         let router = MCPRequestRouter(container: SampleClips.makeContainer())
         let req = JSONRPCRequest(jsonrpc: "2.0", id: .number(2),
                                  method: "tools/list", params: nil)
@@ -42,7 +42,20 @@ final class MCPRouterTests: XCTestCase {
         guard case .object(let r) = resp.result!,
               case .array(let tools) = r["tools"]!
         else { XCTFail("Bad shape"); return }
-        XCTAssertEqual(tools.count, 5)
+        let names = Set(tools.compactMap { tool -> String? in
+            guard case .object(let fields) = tool,
+                  case .string(let name) = fields["name"] else { return nil }
+            return name
+        })
+        XCTAssertEqual(names, [
+            "clipboard_get_current",
+            "clipboard_search",
+            "clipboard_get",
+            "clipboard_list_recent_apps",
+            "clipboard_set",
+            "clipboard_select_item",
+            "ui_show_quick_panel",
+        ])
     }
 
     func testToolsCallDispatchesToCorrectTool() async throws {

--- a/Tests/BridgeTests/MCPToolsTests.swift
+++ b/Tests/BridgeTests/MCPToolsTests.swift
@@ -45,8 +45,9 @@ final class MCPToolsTests: XCTestCase {
               case .object(let first) = arr.first!,
               case .string(let text) = first["text"]!
         else { XCTFail("Bad shape"); return }
-        let items = try JSONDecoder().decode([SearchHistoryTool.OutputItem].self,
-                                              from: text.data(using: .utf8)!)
+        let output = try JSONDecoder().decode(SearchHistoryTool.Output.self,
+                                               from: text.data(using: .utf8)!)
+        let items = output.items
         XCTAssertEqual(items.count, 1)
         XCTAssertEqual(items[0].title, "Hello world")
     }
@@ -63,10 +64,85 @@ final class MCPToolsTests: XCTestCase {
               case .object(let first) = arr.first!,
               case .string(let text) = first["text"]!
         else { XCTFail("Bad shape"); return }
-        let items = try JSONDecoder().decode([SearchHistoryTool.OutputItem].self,
-                                              from: text.data(using: .utf8)!)
+        let output = try JSONDecoder().decode(SearchHistoryTool.Output.self,
+                                               from: text.data(using: .utf8)!)
+        let items = output.items
         // 5 条样本 - 1 敏感（默认过滤）= 4
         XCTAssertEqual(items.count, 4)
+    }
+
+    func testSearchEmptyQueryUsesQuickPanelDisplayOrder() async throws {
+        let container = SampleClips.makeContainer()
+        let context = container.mainContext
+        let createdNewer = ClipItem(
+            content: "created newer, used older",
+            contentType: .text,
+            createdAt: Date(timeIntervalSince1970: 200),
+            lastUsedAt: Date(timeIntervalSince1970: 100)
+        )
+        let usedNewer = ClipItem(
+            content: "created older, used newer",
+            contentType: .text,
+            createdAt: Date(timeIntervalSince1970: 100),
+            lastUsedAt: Date(timeIntervalSince1970: 300)
+        )
+        context.insert(createdNewer)
+        context.insert(usedNewer)
+        try context.save()
+
+        let tool = SearchHistoryTool()
+        let result = try await tool.call(
+            params: .object(["limit": .number(2)]),
+            container: container,
+            guardLayer: PrivacyGuard(allowSensitive: false, sourceAppBlocklist: [])
+        )
+
+        guard case .object(let outer) = result,
+              case .array(let arr) = outer["content"]!,
+              case .object(let first) = arr.first!,
+              case .string(let text) = first["text"]!
+        else { XCTFail("Bad shape"); return }
+        let output = try JSONDecoder().decode(SearchHistoryTool.Output.self,
+                                               from: text.data(using: .utf8)!)
+        let items = output.items
+        XCTAssertEqual(items.map(\.title), [
+            "created older, used newer",
+            "created newer, used older"
+        ])
+    }
+
+    func testSelectItemMarksPasteboardWithoutReorderingHistory() async throws {
+        let container = SampleClips.makeContainer()
+        let context = container.mainContext
+        let originalLastUsedAt = Date(timeIntervalSince1970: 100)
+        let item = ClipItem(
+            content: "prepared paste content",
+            contentType: .text,
+            createdAt: Date(timeIntervalSince1970: 90),
+            lastUsedAt: originalLastUsedAt
+        )
+        context.insert(item)
+        try context.save()
+
+        let result = try await PreparePasteTool().call(
+            params: .object(["id": .string(item.itemID)]),
+            container: container,
+            guardLayer: PrivacyGuard(allowSensitive: false, sourceAppBlocklist: [])
+        )
+
+        guard case .object(let outer) = result,
+              case .array(let arr) = outer["content"]!,
+              case .object(let first) = arr.first!,
+              case .string(let text) = first["text"]!
+        else { XCTFail("Bad shape"); return }
+        let output = try JSONDecoder().decode(PreparePasteTool.Output.self,
+                                              from: text.data(using: .utf8)!)
+        XCTAssertTrue(output.written)
+        XCTAssertEqual(output.item_id, item.itemID)
+        XCTAssertEqual(NSPasteboard.general.string(forType: .string), "prepared paste content")
+        XCTAssertTrue(NSPasteboard.general.isPasteMemoWrite)
+        XCTAssertEqual(ClipboardManager.shared.lastChangeCount, NSPasteboard.general.changeCount)
+        XCTAssertEqual(item.lastUsedAt, originalLastUsedAt)
     }
 
     func testSearchPreviewTruncatedAt200() async throws {
@@ -84,8 +160,9 @@ final class MCPToolsTests: XCTestCase {
               case .object(let first) = arr.first!,
               case .string(let text) = first["text"]!
         else { XCTFail("Bad shape"); return }
-        let items = try JSONDecoder().decode([SearchHistoryTool.OutputItem].self,
-                                              from: text.data(using: .utf8)!)
+        let output = try JSONDecoder().decode(SearchHistoryTool.Output.self,
+                                               from: text.data(using: .utf8)!)
+        let items = output.items
         XCTAssertEqual(items.count, 1)
         XCTAssertEqual(items[0].content_preview.count, 200)
     }


### PR DESCRIPTION
## Summary

Adds two new MCP tools and fixes a sort-order mismatch:

### New tools

**`clipboard_select_item`**

Loads an existing clipboard history item onto the system pasteboard using PasteMemo's internal `writeToPasteboard` path (with the self-write marker). This means:

- No duplicate history entry is created (unlike `clipboard_set`, which writes arbitrary text and triggers history capture)
- Existing items are not reordered (no `lastUsedAt` bump)
- The pasteboard carries the full-fidelity content (rich text, file URLs, images) exactly as the Quick Panel would produce

Use case: external automation and AI agents that need to "select" a specific history item for the user to paste, without the side effect of polluting or reordering the history list.

**`ui_show_quick_panel`**

Opens the Quick Paste panel programmatically, independent of the user-configurable global hotkey. Useful when an external tool wants to surface the clipboard history UI on demand.

### Bug fix: SearchHistoryTool sort order

`clipboard_search` was sorted by `createdAt DESC` only, while the Quick Panel displays items by `lastUsedAt DESC, createdAt DESC`. This mismatch meant index-based selection from search results did not match what the user sees in the panel. Fixed to use the same compound sort as the Quick Panel.

### Tests

- `testSearchEmptyQueryUsesQuickPanelDisplayOrder` — verifies items where `lastUsedAt` differs from `createdAt` are returned in `lastUsedAt` order
- `testSelectItemMarksPasteboardWithoutReorderingHistory` — verifies pasteboard is written, self-write marker is set, `lastChangeCount` is updated, and `lastUsedAt` is **not** bumped
- `testToolsListReturnsRegisteredTools` — updated to assert the full set of 7 registered tool names
- Existing search tests fixed to decode `SearchHistoryTool.Output` (was decoding bare array — pre-existing test drift)

### MCPInstructions

Updated the server-level instructions text to list the two new tools and reflect the corrected sort order.

## Checklist

- [x] Tests pass: `swift test --filter MCPToolsTests` (10/10) and `swift test --filter MCPRouterTests` (5/5)
- [x] No new dependencies
- [x] No changes to existing tool behavior (sort order fix is a correction toward the intended display order)
- [x] No mentions of any specific automation tool — both new tools are general-purpose MCP tools